### PR TITLE
Allow the loading of non-local models

### DIFF
--- a/src/epicc/__main__.py
+++ b/src/epicc/__main__.py
@@ -10,6 +10,10 @@ from epicc.ui.export import (
     render_pdf_export_button,
     trigger_print_if_requested,
 )
+from epicc.ui.model_loader import (
+    consume_pending_model_selection,
+    render_load_model_button,
+)
 from epicc.ui.parameters import (
     build_typed_params,
     render_sidebar_parameters,
@@ -19,8 +23,9 @@ from epicc.ui.parameters import (
 )
 from epicc.ui.report import get_report_renderer
 from epicc.ui.state import (
-    has_results,
+    get_custom_models,
     get_run_output,
+    has_results,
     initialize_state,
     set_run_output,
     sync_active_model,
@@ -33,16 +38,27 @@ initialize_state()
 
 all_models = get_all_models()
 model_registry: dict[str, BaseSimulationModel] = {m.human_name(): m for m in all_models}
+model_registry.update(get_custom_models())
 
-hdr_title, hdr_model = st.columns([3, 3])
+_MODEL_SELECT_KEY = "model_selector"
+pending_label = consume_pending_model_selection()
+if pending_label is not None and pending_label in model_registry:
+    st.session_state[_MODEL_SELECT_KEY] = pending_label
+
+hdr_title, hdr_right = st.columns([3, 3])
 hdr_title.title("EPICC Cost Calculator")
-selected_label: str | None = hdr_model.selectbox(
-    "Model",
-    list(model_registry),
-    index=None,
-    placeholder="Select a model...",
-    label_visibility="collapsed",
-)
+
+with hdr_right:
+    col_model, col_load = st.columns([5, 1], vertical_alignment="center")
+    selected_label: str | None = col_model.selectbox(
+        "Model",
+        list(model_registry),
+        key=_MODEL_SELECT_KEY,
+        index=None,
+        placeholder="Select a model...",
+        label_visibility="collapsed",
+    )
+    render_load_model_button(container=col_load)
 
 st.divider()
 
@@ -95,8 +111,10 @@ params = sync_active_model(selected_label)
 param_col, result_col = st.columns([2, 3], gap="large")
 
 with param_col:
-    params, scenario_overrides, model_defaults_flat, has_input_errors = render_sidebar_parameters(
-        active_model, selected_label, params, container=param_col
+    params, scenario_overrides, model_defaults_flat, has_input_errors = (
+        render_sidebar_parameters(
+            active_model, selected_label, params, container=param_col
+        )
     )
 
     typed_params = None
@@ -107,14 +125,17 @@ with param_col:
             render_validation_error(selected_label, exc, container=param_col)
             has_input_errors = True
 
-    # Reset and Save Parameters buttons side by side 
+    # Reset and Save Parameters buttons side by side
     button_col1, button_col2 = st.columns(2)
-    
+
     # Reset Parameters button
     def _handle_reset() -> None:
         model_label = cast(str, selected_label)  # Safe because we checked above
         reset_parameters_to_defaults(
-            model_defaults_flat, params, model_label, param_specs=active_model.parameter_specs
+            model_defaults_flat,
+            params,
+            model_label,
+            param_specs=active_model.parameter_specs,
         )
         # Reset scenarios back to model defaults
         default_scenarios = active_model.default_scenarios
@@ -124,10 +145,10 @@ with param_col:
                 default_scenarios,
                 active_model.scenario_parameter_specs or {},
             )
-    
+
     with button_col1:
-        st.button("Reset Parameters", on_click=_handle_reset, width='stretch')
-    
+        st.button("Reset Parameters", on_click=_handle_reset, width="stretch")
+
     # Save Parameters button (only enabled when parameters are valid)
     with button_col2:
         if typed_params is not None:
@@ -138,11 +159,16 @@ with param_col:
                 container=button_col2,
             )
         else:
-            st.button("Save Parameters", disabled=True, width='stretch', help="Fix parameter errors first")
+            st.button(
+                "Save Parameters",
+                disabled=True,
+                width="stretch",
+                help="Fix parameter errors first",
+            )
 
     st.divider()
     run_clicked = st.button(
-        "Run Simulation", disabled=has_input_errors, width='stretch', type='primary'
+        "Run Simulation", disabled=has_input_errors, width="stretch", type="primary"
     )
 
 with result_col:
@@ -163,7 +189,7 @@ with result_col:
     renderer = get_report_renderer(active_model)
     _HINT = "This report has not been filled, since your simulation has not been run. Run the simulation to see the results here."
 
-    with st.container(key='results-report'):
+    with st.container(key="results-report"):
         if has_results():
             renderer.render(get_run_output())
         else:
@@ -171,4 +197,3 @@ with result_col:
 
     st.divider()
     render_pdf_export_button(container=result_col)
-

--- a/src/epicc/model/models/__init__.py
+++ b/src/epicc/model/models/__init__.py
@@ -1,7 +1,8 @@
 import importlib.resources
 import sys
+from typing import IO
 
-from epicc.formats import get_format, opaque_to_typed
+from epicc.formats import read_from_format
 from epicc.model.base import BaseSimulationModel
 from epicc.model.factory import create_model_instance
 from epicc.model.schema import Model
@@ -12,38 +13,26 @@ MODEL_REGISTRY = [
 ]
 
 
+def load_model_from_stream(filename: str, stream: IO[bytes]) -> BaseSimulationModel:
+    model_def, _ = read_from_format(filename, stream, Model)
+    return create_model_instance(model_def, source_path=filename)
+
+
 def get_all_models() -> list[BaseSimulationModel]:
     models = []
 
     for model_name in MODEL_REGISTRY:
+        filename = f"epicc.model.models/{model_name}.yaml"
         try:
-            # Get the resource file from the package
-            model_resource = importlib.resources.files("epicc.model.models").joinpath(
+            resource = importlib.resources.files("epicc.model.models").joinpath(
                 f"{model_name}.yaml"
             )
-
-            with model_resource.open("rb") as f:
-                yaml_format = get_format(f"{model_name}.yaml")
-                data, _ = yaml_format.read(f)
-
-            # Validate against Model schema
-            model_def = opaque_to_typed(data, Model)
-
-            # Create model instance from definition
-            model = create_model_instance(
-                model_def, source_path=f"epicc.model.models/{model_name}.yaml"
-            )
-            models.append(model)
-
+            with resource.open("rb") as f:
+                models.append(load_model_from_stream(filename, f))
         except Exception as e:
-            print(
-                f"warning: failed to load model '{model_name}': {e}",
-                file=sys.stderr,
-            )
-
-            continue
+            print(f"warning: failed to load model '{model_name}': {e}", file=sys.stderr)
 
     return models
 
 
-__all__ = ["get_all_models", "MODEL_REGISTRY"]
+__all__ = ["get_all_models", "load_model_from_stream", "MODEL_REGISTRY"]

--- a/src/epicc/ui/model_loader.py
+++ b/src/epicc/ui/model_loader.py
@@ -25,6 +25,10 @@ def _infer_filename_from_url(url: str) -> str:
     return filename
 
 
+def _custom_model_key(name: str) -> str:
+    return f"[Custom] {name}"
+
+
 def _decode_model_code(code: str) -> bytes:
     """Decode a base64-encoded, LZMA-compressed YAML model code into raw YAML bytes."""
     _MAX_OUTPUT = 2 * 1024 * 1024  # 2 MiB safety cap against decompression bombs
@@ -67,8 +71,8 @@ def _load_model_dialog() -> None:
                     model = load_model_from_stream(
                         uploaded.name, io.BytesIO(uploaded.read())
                     )
-                add_custom_model(model.human_name(), model)
-                st.session_state[_PENDING_MODEL_KEY] = model.human_name()
+                key = add_custom_model(_custom_model_key(model.human_name()), model)
+                st.session_state[_PENDING_MODEL_KEY] = key
                 st.rerun()
             except Exception as exc:
                 st.error(f"Could not load model: {exc}")
@@ -99,8 +103,8 @@ def _load_model_dialog() -> None:
 
                 filename = _infer_filename_from_url(url)
                 model = load_model_from_stream(filename, io.BytesIO(raw))
-                add_custom_model(model.human_name(), model)
-                st.session_state[_PENDING_MODEL_KEY] = model.human_name()
+                key = add_custom_model(_custom_model_key(model.human_name()), model)
+                st.session_state[_PENDING_MODEL_KEY] = key
                 st.rerun()
             except urllib.error.URLError as exc:
                 reason = exc.reason if hasattr(exc, "reason") else str(exc)
@@ -129,8 +133,8 @@ def _load_model_dialog() -> None:
                     model = load_model_from_stream(
                         "model.yaml", io.BytesIO(_decode_model_code(code))
                     )
-                add_custom_model(model.human_name(), model)
-                st.session_state[_PENDING_MODEL_KEY] = model.human_name()
+                key = add_custom_model(_custom_model_key(model.human_name()), model)
+                st.session_state[_PENDING_MODEL_KEY] = key
                 st.rerun()
             except Exception as exc:
                 st.error(f"Could not load model: {exc}")

--- a/src/epicc/ui/model_loader.py
+++ b/src/epicc/ui/model_loader.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import base64
+import io
+import lzma
+import urllib.error
+import urllib.request
+from typing import Any
+
+import streamlit as st
+
+from epicc.model.models import load_model_from_stream
+from epicc.ui.state import add_custom_model
+
+_PENDING_MODEL_KEY = "_pending_model_selection"
+
+
+def _infer_filename_from_url(url: str) -> str:
+    base = url.split("?")[0].split("#")[0].rstrip("/")
+    filename = base.rsplit("/", 1)[-1] if "/" in base else base
+    if not filename:
+        filename = "model.yaml"
+    elif not filename.lower().endswith((".yaml", ".yml")):
+        filename += ".yaml"
+    return filename
+
+
+def _decode_model_code(code: str) -> bytes:
+    """Decode a base64-encoded, LZMA-compressed YAML model code into raw YAML bytes."""
+    compressed = base64.b64decode(code.strip())
+    return lzma.decompress(compressed)
+
+
+@st.dialog("Load Custom Model", width="large")
+def _load_model_dialog() -> None:
+    st.markdown(
+        "Load a model from a local YAML file, from a URL, or by pasting a model code. "
+        "Custom models are available for the rest of this browser session."
+    )
+
+    tab_file, tab_url, tab_code = st.tabs(
+        ["Upload File", "Load from URL", "Use a Model Code"]
+    )
+
+    with tab_file:
+        uploaded = st.file_uploader(
+            "YAML model file",
+            type=["yaml", "yml"],
+            label_visibility="collapsed",
+        )
+
+        load_file_btn = st.button(
+            "Load",
+            key="load_model_file_btn",
+            type="primary",
+            disabled=uploaded is None,
+        )
+
+        if load_file_btn and uploaded is not None:
+            try:
+                with st.spinner("Parsing model..."):
+                    model = load_model_from_stream(
+                        uploaded.name, io.BytesIO(uploaded.read())
+                    )
+                add_custom_model(model.human_name(), model)
+                st.session_state[_PENDING_MODEL_KEY] = model.human_name()
+                st.rerun()
+            except Exception as exc:
+                st.error(f"Could not load model: {exc}")
+
+    with tab_url:
+        url = st.text_input(
+            "Model URL",
+            placeholder="https://example.com/model.yaml",
+            label_visibility="collapsed",
+        )
+
+        load_url_btn = st.button(
+            "Load",
+            key="load_model_url_btn",
+            type="primary",
+            disabled=not bool(url),
+        )
+
+        if load_url_btn and url:
+            try:
+                with st.spinner("Fetching model..."):
+                    req = urllib.request.Request(
+                        url,
+                        headers={"User-Agent": "epicc/0.1"},
+                    )
+                    with urllib.request.urlopen(req, timeout=15) as response:  # noqa: S310
+                        raw = response.read()
+
+                filename = _infer_filename_from_url(url)
+                model = load_model_from_stream(filename, io.BytesIO(raw))
+                add_custom_model(model.human_name(), model)
+                st.session_state[_PENDING_MODEL_KEY] = model.human_name()
+                st.rerun()
+            except urllib.error.URLError as exc:
+                reason = exc.reason if hasattr(exc, "reason") else str(exc)
+                st.error(f"Could not fetch URL: {reason}")
+            except Exception as exc:
+                st.error(f"Could not load model: {exc}")
+
+    with tab_code:
+        code = st.text_area(
+            "Model code",
+            placeholder="Paste your model code here...",
+            label_visibility="collapsed",
+            height=160,
+        )
+
+        load_code_btn = st.button(
+            "Load",
+            key="load_model_code_btn",
+            type="primary",
+            disabled=not bool(code),
+        )
+
+        if load_code_btn and code:
+            try:
+                with st.spinner("Decoding model..."):
+                    model = load_model_from_stream(
+                        "model.yaml", io.BytesIO(_decode_model_code(code))
+                    )
+                add_custom_model(model.human_name(), model)
+                st.session_state[_PENDING_MODEL_KEY] = model.human_name()
+                st.rerun()
+            except Exception as exc:
+                st.error(f"Could not load model: {exc}")
+
+
+def render_load_model_button(container: Any = None) -> None:
+    rc = container if container is not None else st
+    if rc.button(
+        "Other...",
+        key="open_load_model_dialog",
+        help="Load a model from a local YAML file or from a URL",
+        use_container_width=True,
+    ):
+        _load_model_dialog()
+
+
+def consume_pending_model_selection() -> str | None:
+    return st.session_state.pop(_PENDING_MODEL_KEY, None)

--- a/src/epicc/ui/model_loader.py
+++ b/src/epicc/ui/model_loader.py
@@ -27,8 +27,13 @@ def _infer_filename_from_url(url: str) -> str:
 
 def _decode_model_code(code: str) -> bytes:
     """Decode a base64-encoded, LZMA-compressed YAML model code into raw YAML bytes."""
+    _MAX_OUTPUT = 2 * 1024 * 1024  # 2 MiB safety cap against decompression bombs
     compressed = base64.b64decode(code.strip())
-    return lzma.decompress(compressed)
+    decompressor = lzma.LZMADecompressor()
+    data = decompressor.decompress(compressed, max_length=_MAX_OUTPUT + 1)
+    if len(data) > _MAX_OUTPUT or not decompressor.eof:
+        raise ValueError("Model code expands beyond 2 MiB")
+    return data
 
 
 @st.dialog("Load Custom Model", width="large")

--- a/src/epicc/ui/model_loader.py
+++ b/src/epicc/ui/model_loader.py
@@ -85,12 +85,17 @@ def _load_model_dialog() -> None:
         if load_url_btn and url:
             try:
                 with st.spinner("Fetching model..."):
+                    if not url.lower().startswith(("http://", "https://")):
+                        raise ValueError("Only http(s) URLs are supported")
                     req = urllib.request.Request(
                         url,
                         headers={"User-Agent": "epicc/0.1"},
                     )
                     with urllib.request.urlopen(req, timeout=15) as response:  # noqa: S310
-                        raw = response.read()
+                        max_bytes = 2 * 1024 * 1024  # 2 MiB safety cap
+                        raw = response.read(max_bytes + 1)
+                        if len(raw) > max_bytes:
+                            raise ValueError("Model file is too large (max 2 MiB)")
 
                 filename = _infer_filename_from_url(url)
                 model = load_model_from_stream(filename, io.BytesIO(raw))

--- a/src/epicc/ui/model_loader.py
+++ b/src/epicc/ui/model_loader.py
@@ -13,6 +13,7 @@ from epicc.model.models import load_model_from_stream
 from epicc.ui.state import add_custom_model
 
 _PENDING_MODEL_KEY = "_pending_model_selection"
+_MAX_MODEL_BYTES = 2 * 1024 * 1024  # 2 MiB cap applied to all model inputs
 
 
 def _infer_filename_from_url(url: str) -> str:
@@ -31,11 +32,14 @@ def _custom_model_key(name: str) -> str:
 
 def _decode_model_code(code: str) -> bytes:
     """Decode a base64-encoded, LZMA-compressed YAML model code into raw YAML bytes."""
-    _MAX_OUTPUT = 2 * 1024 * 1024  # 2 MiB safety cap against decompression bombs
-    compressed = base64.b64decode(code.strip())
+    stripped = code.strip()
+    # base64 encodes 3 bytes → 4 chars; a _MAX_MODEL_BYTES payload needs ~4/3× that many chars
+    if len(stripped) > _MAX_MODEL_BYTES * 4 // 3 + 64:
+        raise ValueError("Model code is too large (max 2 MiB)")
+    compressed = base64.b64decode(stripped, validate=True)
     decompressor = lzma.LZMADecompressor()
-    data = decompressor.decompress(compressed, max_length=_MAX_OUTPUT + 1)
-    if len(data) > _MAX_OUTPUT or not decompressor.eof:
+    data = decompressor.decompress(compressed, max_length=_MAX_MODEL_BYTES + 1)
+    if len(data) > _MAX_MODEL_BYTES or not decompressor.eof:
         raise ValueError("Model code expands beyond 2 MiB")
     return data
 
@@ -68,8 +72,11 @@ def _load_model_dialog() -> None:
         if load_file_btn and uploaded is not None:
             try:
                 with st.spinner("Parsing model..."):
+                    raw = uploaded.read(_MAX_MODEL_BYTES + 1)
+                    if len(raw) > _MAX_MODEL_BYTES:
+                        raise ValueError("Model file is too large (max 2 MiB)")
                     model = load_model_from_stream(
-                        uploaded.name, io.BytesIO(uploaded.read())
+                        uploaded.name, io.BytesIO(raw)
                     )
                 key = add_custom_model(_custom_model_key(model.human_name()), model)
                 st.session_state[_PENDING_MODEL_KEY] = key
@@ -101,9 +108,8 @@ def _load_model_dialog() -> None:
                         headers={"User-Agent": "epicc/0.1"},
                     )
                     with urllib.request.urlopen(req, timeout=15) as response:  # noqa: S310
-                        max_bytes = 2 * 1024 * 1024  # 2 MiB safety cap
-                        raw = response.read(max_bytes + 1)
-                        if len(raw) > max_bytes:
+                        raw = response.read(_MAX_MODEL_BYTES + 1)
+                        if len(raw) > _MAX_MODEL_BYTES:
                             raise ValueError("Model file is too large (max 2 MiB)")
 
                 filename = _infer_filename_from_url(url)

--- a/src/epicc/ui/state.py
+++ b/src/epicc/ui/state.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import streamlit as st
+
+if TYPE_CHECKING:
+    from epicc.model.base import BaseSimulationModel
 
 _RESULTS_KEY = "results_payload"
 _PRINT_REQUESTED_KEY = "print_requested"
@@ -11,12 +14,14 @@ _ACTIVE_MODEL_KEY = "active_model_key"
 _ACTIVE_PARAM_IDENTITY_KEY = "active_param_identity"
 _PARAMS_KEY = "params"
 _UPLOAD_HASH_CACHE_KEY = "_upload_hash_cache"
+_CUSTOM_MODELS_KEY = "custom_models"
 
 
 def initialize_state() -> None:
     st.session_state.setdefault(_RESULTS_KEY, None)
     st.session_state.setdefault(_PRINT_REQUESTED_KEY, False)
     st.session_state.setdefault(_PRINT_TOKEN_KEY, 0)
+    st.session_state.setdefault(_CUSTOM_MODELS_KEY, {})
 
 
 def clear_results() -> None:
@@ -30,7 +35,6 @@ def sync_active_model(model_key: str) -> dict[str, Any]:
         st.session_state[_ACTIVE_MODEL_KEY] = model_key
         st.session_state[_PARAMS_KEY] = {}
         clear_results()
-        # Clear file uploader state when switching models
         st.session_state.pop(_UPLOAD_HASH_CACHE_KEY, None)
         st.session_state.pop(_ACTIVE_PARAM_IDENTITY_KEY, None)
 
@@ -70,3 +74,13 @@ def set_active_param_identity(identity: tuple) -> None:
 def reset_params() -> dict[str, Any]:
     st.session_state[_PARAMS_KEY] = {}
     return st.session_state[_PARAMS_KEY]
+
+
+def get_custom_models() -> "dict[str, BaseSimulationModel]":
+    return st.session_state.get(_CUSTOM_MODELS_KEY, {})
+
+
+def add_custom_model(name: str, model: "BaseSimulationModel") -> None:
+    if _CUSTOM_MODELS_KEY not in st.session_state:
+        st.session_state[_CUSTOM_MODELS_KEY] = {}
+    st.session_state[_CUSTOM_MODELS_KEY][name] = model

--- a/src/epicc/ui/state.py
+++ b/src/epicc/ui/state.py
@@ -80,7 +80,16 @@ def get_custom_models() -> "dict[str, BaseSimulationModel]":
     return st.session_state.get(_CUSTOM_MODELS_KEY, {})
 
 
-def add_custom_model(name: str, model: "BaseSimulationModel") -> None:
+def add_custom_model(name: str, model: "BaseSimulationModel") -> str:
+    """Add a custom model and return the key it was stored under."""
     if _CUSTOM_MODELS_KEY not in st.session_state:
         st.session_state[_CUSTOM_MODELS_KEY] = {}
-    st.session_state[_CUSTOM_MODELS_KEY][name] = model
+    existing = st.session_state[_CUSTOM_MODELS_KEY]
+    key = name
+    counter = 2
+    while key in existing:
+        key = f"{name} ({counter})"
+        counter += 1
+    # counter is local to `name`, so "Model A (2)" and "Model B (2)" are independent
+    existing[key] = model
+    return key


### PR DESCRIPTION
Allow for loading models not on the computer, through URLs or model codes (compressed blobs of text).

Fix #37