### PR TITLE
Share links now use readable query parameters instead of an encoded blob (v0.1.0 links stop working)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,39 @@ https://epiworldpythonapp.streamlit.app/
 
 Please follow instructions in your console for loading development versions.
 
+## Sharing a calculation by URL
+
+The address bar is a permalink. As you change parameters the app rewrites the query
+string, so copying the URL is enough to hand someone the exact calculation you are
+looking at.
+
+The query string is meant to be read — and edited — by hand:
+
+```
+https://epiworldpythonapp.streamlit.app/?model=measles&vaccination_rate=0.9&scen.22_cases.label=Small+outbreak&scen.22_cases.n_cases=30
+```
+
+| Key | Meaning |
+| --- | --- |
+| `model` | Which model to open, named by its YAML file stem (`measles`, `tb_isolation`). Required. |
+| `<parameter>` | A parameter value, keyed by its id in the model YAML. |
+| `scen.<scenario>.<variable>` | A scenario variable, keyed by scenario id. |
+| `scen.<scenario>.label` | A scenario's display label. |
+| `scenarios` | Comma-separated scenario ids, in order. Only needed if you add, remove, or reorder scenarios. |
+
+Only values that differ from the model's defaults appear, so a link shows exactly what
+was changed and nothing else. Open a model without changing anything and the URL stays
+at `?model=measles`.
+
+Because links carry changes rather than a full snapshot, a link opened after the model's
+defaults change will pick up the new defaults for everything it does not mention. Use the
+parameter export (**Save Changes as Preset**) when you need a calculation pinned exactly.
+
+Keys the app does not recognise are ignored, and values that cannot be honoured — a
+number past its allowed range, an unknown option, a typo — are clamped or dropped with a
+warning shown in the app rather than failing silently. `model` and `scenarios` are
+reserved key names and cannot be used as parameter ids.
+
 ## Versioning and release notes
 
 The project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The

--- a/README.md
+++ b/README.md
@@ -55,10 +55,17 @@ Because links carry changes rather than a full snapshot, a link opened after the
 defaults change will pick up the new defaults for everything it does not mention. Use the
 parameter export (**Save Changes as Preset**) when you need a calculation pinned exactly.
 
-Keys the app does not recognise are ignored, and values that cannot be honoured — a
-number past its allowed range, an unknown option, a typo — are clamped or dropped with a
-warning shown in the app rather than failing silently. `model` and `scenarios` are
-reserved key names and cannot be used as parameter ids.
+Keys the app does not recognise are ignored. Values that cannot be honoured are reported
+with a warning in the app rather than failing silently: a number past its allowed range
+is clamped to the range, and an unknown option, a fractional value for a whole-number
+parameter, or a misspelled key is dropped. `model`, `scenarios`, and Streamlit's own
+`embed` and `embed_options` are reserved key names and cannot be used as parameter ids.
+
+Two cases produce no link. A model that isn't loaded in the browser — an uploaded one, or
+one from a newer version of the app — leaves the link pending with a warning; load that
+model and its values are applied then. And while you are trying unsaved edits from the
+model editor, the URL is cleared, because a link can carry parameter values but not the
+edits themselves, so it would reopen the saved model showing different numbers.
 
 ## Versioning and release notes
 

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ looking at.
 The query string is meant to be read — and edited — by hand:
 
 ```
-https://epiworldpythonapp.streamlit.app/?model=measles&vaccination_rate=0.9&scen.22_cases.label=Small+outbreak&scen.22_cases.n_cases=30
+https://epiworldpythonapp.streamlit.app/?model=measles&param.vaccination_rate=0.9&scen.22_cases.label=Small+outbreak&scen.22_cases.n_cases=30
 ```
 
 | Key | Meaning |
 | --- | --- |
 | `model` | Which model to open, named by its YAML file stem (`measles`, `tb_isolation`). Required. |
-| `<parameter>` | A parameter value, keyed by its id in the model YAML. |
+| `param.<parameter>` | An equation parameter value, keyed by its id in the model YAML. |
 | `scen.<scenario>.<variable>` | A scenario variable, keyed by scenario id. |
 | `scen.<scenario>.label` | A scenario's display label. |
 | `scenarios` | Comma-separated scenario ids, in order. Only needed if you add, remove, or reorder scenarios. |
@@ -56,16 +56,21 @@ defaults change will pick up the new defaults for everything it does not mention
 parameter export (**Save Changes as Preset**) when you need a calculation pinned exactly.
 
 Keys the app does not recognise are ignored. Values that cannot be honoured are reported
-with a warning in the app rather than failing silently: a number past its allowed range
-is clamped to the range, and an unknown option, a fractional value for a whole-number
-parameter, or a misspelled key is dropped. `model`, `scenarios`, and Streamlit's own
-`embed` and `embed_options` are reserved key names and cannot be used as parameter ids.
+with a warning in the app rather than failing silently: a number past its model-declared
+range is clamped to the range, while an unknown option, a fractional or browser-unsafe
+whole number, or a misspelled key is dropped. Equation parameters live under `param.`,
+so even ids such as `model`, `scenarios`, `embed`, and `embed_options` cannot collide
+with the app's or Streamlit's top-level query keys. Write a parameter without that
+prefix and the app says so, rather than treating it as a stray key and leaving the
+default in place.
 
-Two cases produce no link. A model that isn't loaded in the browser — an uploaded one, or
-one from a newer version of the app — leaves the link pending with a warning; load that
-model and its values are applied then. And while you are trying unsaved edits from the
-model editor, the URL is cleared, because a link can carry parameter values but not the
-edits themselves, so it would reopen the saved model showing different numbers.
+A model that isn't loaded in the browser — an uploaded one, or one from a newer version
+of the app — leaves its link pending with a warning; load that model and its values are
+applied then. If multiple loaded models use the same YAML filename, link sharing is
+disabled until the custom file is renamed, because its short URL name would be ambiguous.
+While you are trying unsaved edits from the model editor, the URL is also cleared: a link
+can carry parameter values but not the edits themselves, so it would reopen the saved
+model showing different numbers.
 
 ## Versioning and release notes
 
@@ -86,8 +91,9 @@ That updates the version in `src/epicc/__init__.py` and `pyproject.toml`, then p
 the commands to finish:
 
 ```
-git commit -am "Release v0.2.0"
-git tag -a v0.2.0 -m "v0.2.0"
+release_version=1.2.3       # replace with the version printed by make bump
+git commit -am "Release v${release_version}"
+git tag -a "v${release_version}" -m "v${release_version}"
 git push --follow-tags
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "epicc"
-version = "0.2.0"
+version = "1.0.0"
 requires-python = ">=3.12"
 dependencies = [
     "streamlit>=1.55.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "epicc"
-version = "0.1.0"
+version = "0.2.0"
 requires-python = ">=3.12"
 dependencies = [
     "streamlit>=1.55.0",

--- a/src/epicc/__init__.py
+++ b/src/epicc/__init__.py
@@ -7,6 +7,6 @@ unavailable there. `pyproject.toml` is kept in step with this value by
 `scripts/bump_version.py` and checked by `tests/epicc/test_version.py`.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = ["__version__"]

--- a/src/epicc/__init__.py
+++ b/src/epicc/__init__.py
@@ -7,6 +7,6 @@ unavailable there. `pyproject.toml` is kept in step with this value by
 `scripts/bump_version.py` and checked by `tests/epicc/test_version.py`.
 """
 
-__version__ = "0.2.0"
+__version__ = "1.0.0"
 
 __all__ = ["__version__"]

--- a/src/epicc/__main__.py
+++ b/src/epicc/__main__.py
@@ -42,7 +42,7 @@ from epicc.ui.state import (
     sync_active_model,
 )
 from epicc.ui.styles import load_styles, render_brand_header
-from epicc.ui.url_params import read_url_params, write_url_params
+from epicc.ui.url_params import model_slug, read_url_state, write_url_state
 
 st.set_page_config(page_title=CONFIG.app.title, layout="wide")
 load_styles(CONFIG.brand)
@@ -54,31 +54,34 @@ model_registry.update(get_custom_models())
 
 # Restore model selection and parameters from URL query string on first load.
 _URL_APPLIED_KEY = "_url_params_applied"
+_URL_WARNINGS_KEY = "_url_params_warnings"
 if not st.session_state.get(_URL_APPLIED_KEY):
-    _url_result = read_url_params()
-    if _url_result is not None:
-        _url_model, _url_values, _url_scenarios = _url_result
-        if _url_model in model_registry:
-            st.session_state[_URL_APPLIED_KEY] = True
-            st.session_state["model_selector"] = _url_model
+    # Set unconditionally so the restore is genuinely one-shot, even when the
+    # link names a model we don't have.
+    st.session_state[_URL_APPLIED_KEY] = True
+    _url_state = read_url_state(model_registry)
+    if _url_state is not None:
+        if _url_state.warnings:
+            st.session_state[_URL_WARNINGS_KEY] = _url_state.warnings
+        if _url_state.model_label is not None:
+            _url_label = _url_state.model_label
+            st.session_state["model_selector"] = _url_label
             # Activate the model and populate its keyed widgets before they render.
-            _url_params = sync_active_model(_url_model)
+            _url_params = sync_active_model(_url_label)
             set_active_param_identity(DEFAULT_PARAM_IDENTITY)
-            _url_active_model = model_registry[_url_model]
+            _url_active_model = model_registry[_url_label]
             reset_parameters_to_defaults(
-                _url_values,
+                _url_state.params,
                 _url_params,
-                _url_model,
+                _url_label,
                 param_specs=_url_active_model.parameter_specs,
             )
-            if _url_scenarios:
+            if _url_state.scenarios:
                 reset_scenario_state(
-                    _url_model,
-                    _url_scenarios,
+                    _url_label,
+                    _url_state.scenarios,
                     _url_active_model.scenario_parameter_specs or {},
                 )
-    else:
-        st.session_state[_URL_APPLIED_KEY] = True
 
 _EDITOR_MODE_KEY = "epicc_editor_mode"
 _MODEL_SELECT_KEY = "model_selector"
@@ -145,6 +148,9 @@ elif selected_label is not None:
 
 st.divider()
 
+for _url_warning in st.session_state.pop(_URL_WARNINGS_KEY, []):
+    st.warning(_url_warning)
+
 if selected_label is None:
     if in_editor:
 
@@ -182,9 +188,12 @@ implications of different policy scenarios.
    values it uses. Read the parameter descriptions before you run, and treat outputs
    with the caveats in mind.
 
- - **Save and share your work:** Export your current parameters and send them to a
-   colleague, so they can pick up exactly where you left off, or reload them yourself
-   any time you want to revisit the analysis.
+ - **Share a link:** The address bar tracks whatever you change, in plain text, so
+   copying the URL hands a colleague the exact calculation you're looking at. You can
+   read the link, and edit it, before you send it.
+
+ - **Save your work:** Export your current parameters to a file and reload them any
+   time you want to revisit the analysis.
 
  - **Generate a report:** Once you've run a simulation, save the results page as a PDF
    to share directly with stakeholders.{_releases_line}
@@ -265,8 +274,14 @@ with param_col:
             )
         )
 
-        # Keep the URL in sync with current parameter values.
-        write_url_params(selected_label, params, scenario_overrides)
+        # Keep the URL in sync with current parameter values. A preview model has
+        # no source file, so name the selected model in the link instead.
+        write_url_state(
+            active_model,
+            params,
+            scenario_overrides,
+            slug=model_slug(model_registry[selected_label]),
+        )
 
         typed_params = None
         if not has_input_errors:

--- a/src/epicc/__main__.py
+++ b/src/epicc/__main__.py
@@ -42,7 +42,13 @@ from epicc.ui.state import (
     sync_active_model,
 )
 from epicc.ui.styles import load_styles, render_brand_header
-from epicc.ui.url_params import clear_url_state, read_url_state, write_url_state
+from epicc.ui.url_params import (
+    build_slug_registry,
+    clear_url_state,
+    model_slug,
+    read_url_state,
+    write_url_state,
+)
 
 st.set_page_config(page_title=CONFIG.app.title, layout="wide")
 load_styles(CONFIG.brand)
@@ -52,26 +58,48 @@ all_models = get_all_models()
 model_registry: dict[str, BaseSimulationModel] = {m.human_name(): m for m in all_models}
 model_registry.update(get_custom_models())
 
+_EDITOR_MODE_KEY = "epicc_editor_mode"
+_MODEL_SELECT_KEY = "model_selector"
+_URL_APPLIED_KEY = "_url_params_applied"
+_URL_WARNINGS_KEY = "_url_params_warnings"
+_URL_UNRESOLVED_WARNED_KEY = "_url_params_unresolved_warned"
+
+# A just-loaded model is selected on the rerun after the upload dialog closes.
+# Consume that selection before URL resolution so it can disambiguate a pending
+# link whose slug belongs to more than one loaded model.
+pending_label = consume_pending_model_selection()
+if pending_label is not None and pending_label in model_registry:
+    st.session_state[_MODEL_SELECT_KEY] = pending_label
+
 # Restore model selection and parameters from URL query string on first load.
 # A link naming a model that isn't loaded yet stays pending rather than being
 # discarded: the user may still upload that model, and the values should land
-# when they do. Only the warning is one-shot, so it doesn't repeat every rerun.
-_URL_APPLIED_KEY = "_url_params_applied"
-_URL_WARNINGS_KEY = "_url_params_warnings"
-_URL_WARNED_KEY = "_url_params_warned"
+# when they do. Its unresolved warning is one-shot; any value warnings found
+# after the model arrives are still shown.
 if not st.session_state.get(_URL_APPLIED_KEY):
-    _url_state = read_url_state(model_registry)
+    _url_state = read_url_state(
+        model_registry,
+        preferred_label=st.session_state.get(_MODEL_SELECT_KEY),
+    )
     if _url_state is None:
         st.session_state[_URL_APPLIED_KEY] = True
     else:
-        if _url_state.warnings and not st.session_state.get(_URL_WARNED_KEY):
-            st.session_state[_URL_WARNED_KEY] = True
-            st.session_state[_URL_WARNINGS_KEY] = _url_state.warnings
+        if _url_state.warnings:
+            should_queue = _url_state.resolved or not st.session_state.get(
+                _URL_UNRESOLVED_WARNED_KEY
+            )
+            if should_queue:
+                st.session_state[_URL_WARNINGS_KEY] = [
+                    *st.session_state.get(_URL_WARNINGS_KEY, []),
+                    *_url_state.warnings,
+                ]
+            if not _url_state.resolved:
+                st.session_state[_URL_UNRESOLVED_WARNED_KEY] = True
         if _url_state.resolved:
             st.session_state[_URL_APPLIED_KEY] = True
             _url_label = _url_state.model_label
             assert _url_label is not None  # Type narrowing for mypy
-            st.session_state["model_selector"] = _url_label
+            st.session_state[_MODEL_SELECT_KEY] = _url_label
             # Activate the model and populate its keyed widgets before they render.
             _url_params = sync_active_model(_url_label)
             set_active_param_identity(DEFAULT_PARAM_IDENTITY)
@@ -88,9 +116,6 @@ if not st.session_state.get(_URL_APPLIED_KEY):
                     _url_state.scenarios,
                     _url_active_model.scenario_parameter_specs or {},
                 )
-
-_EDITOR_MODE_KEY = "epicc_editor_mode"
-_MODEL_SELECT_KEY = "model_selector"
 
 
 def _activate_preview(model_label: str) -> bool:
@@ -119,10 +144,6 @@ def _activate_preview(model_label: str) -> bool:
 def _discard_preview() -> None:
     discard_preview()
 
-
-pending_label = consume_pending_model_selection()
-if pending_label is not None and pending_label in model_registry:
-    st.session_state[_MODEL_SELECT_KEY] = pending_label
 
 hdr_title, hdr_controls = st.columns([3, 4.25])
 render_brand_header(
@@ -261,11 +282,19 @@ params = sync_active_model(selected_label)
 
 preview_model, preview_label = get_preview()
 using_preview = preview_model is not None and preview_label == selected_label
+selected_slug = model_slug(model_registry[selected_label])
+slug_labels = build_slug_registry(model_registry).get(selected_slug, [])
+slug_is_unique = slug_labels == [selected_label]
 if using_preview and preview_model is not None:
     active_model = preview_model
     st.warning(
         "You're trying an unsaved, edited version of this model. Nothing is saved "
         "yet, and this state can't be shared as a link."
+    )
+elif not slug_is_unique:
+    st.warning(
+        "Link sharing is unavailable because another loaded model uses the same "
+        "YAML filename. Rename the custom model file to give it a unique URL name."
     )
 
 param_col, result_col = st.columns([2, 3], gap="large")
@@ -285,11 +314,11 @@ with param_col:
         # one no longer applies.
         st.session_state[_URL_APPLIED_KEY] = True
 
-        if using_preview:
+        if using_preview or not slug_is_unique:
             # A preview's values are diffed against the *edited* defaults and its
-            # equation changes can't be expressed at all, so any link written here
-            # would reopen the saved model showing different numbers. Publish
-            # nothing rather than something misleading.
+            # equation changes can't be expressed at all. A colliding slug could
+            # resolve to a different model. Publish nothing in either case rather
+            # than leaving a misleading permalink behind.
             clear_url_state()
         else:
             # Keep the URL in sync with current parameter values.

--- a/src/epicc/__main__.py
+++ b/src/epicc/__main__.py
@@ -42,7 +42,7 @@ from epicc.ui.state import (
     sync_active_model,
 )
 from epicc.ui.styles import load_styles, render_brand_header
-from epicc.ui.url_params import model_slug, read_url_state, write_url_state
+from epicc.ui.url_params import clear_url_state, read_url_state, write_url_state
 
 st.set_page_config(page_title=CONFIG.app.title, layout="wide")
 load_styles(CONFIG.brand)
@@ -53,18 +53,24 @@ model_registry: dict[str, BaseSimulationModel] = {m.human_name(): m for m in all
 model_registry.update(get_custom_models())
 
 # Restore model selection and parameters from URL query string on first load.
+# A link naming a model that isn't loaded yet stays pending rather than being
+# discarded: the user may still upload that model, and the values should land
+# when they do. Only the warning is one-shot, so it doesn't repeat every rerun.
 _URL_APPLIED_KEY = "_url_params_applied"
 _URL_WARNINGS_KEY = "_url_params_warnings"
+_URL_WARNED_KEY = "_url_params_warned"
 if not st.session_state.get(_URL_APPLIED_KEY):
-    # Set unconditionally so the restore is genuinely one-shot, even when the
-    # link names a model we don't have.
-    st.session_state[_URL_APPLIED_KEY] = True
     _url_state = read_url_state(model_registry)
-    if _url_state is not None:
-        if _url_state.warnings:
+    if _url_state is None:
+        st.session_state[_URL_APPLIED_KEY] = True
+    else:
+        if _url_state.warnings and not st.session_state.get(_URL_WARNED_KEY):
+            st.session_state[_URL_WARNED_KEY] = True
             st.session_state[_URL_WARNINGS_KEY] = _url_state.warnings
-        if _url_state.model_label is not None:
+        if _url_state.resolved:
+            st.session_state[_URL_APPLIED_KEY] = True
             _url_label = _url_state.model_label
+            assert _url_label is not None  # Type narrowing for mypy
             st.session_state["model_selector"] = _url_label
             # Activate the model and populate its keyed widgets before they render.
             _url_params = sync_active_model(_url_label)
@@ -258,7 +264,8 @@ using_preview = preview_model is not None and preview_label == selected_label
 if using_preview and preview_model is not None:
     active_model = preview_model
     st.warning(
-        "You're trying an unsaved, edited version of this model. Nothing is saved yet."
+        "You're trying an unsaved, edited version of this model. Nothing is saved "
+        "yet, and this state can't be shared as a link."
     )
 
 param_col, result_col = st.columns([2, 3], gap="large")
@@ -274,14 +281,19 @@ with param_col:
             )
         )
 
-        # Keep the URL in sync with current parameter values. A preview model has
-        # no source file, so name the selected model in the link instead.
-        write_url_state(
-            active_model,
-            params,
-            scenario_overrides,
-            slug=model_slug(model_registry[selected_label]),
-        )
+        # We're rendering a model, so any link still waiting on an unavailable
+        # one no longer applies.
+        st.session_state[_URL_APPLIED_KEY] = True
+
+        if using_preview:
+            # A preview's values are diffed against the *edited* defaults and its
+            # equation changes can't be expressed at all, so any link written here
+            # would reopen the saved model showing different numbers. Publish
+            # nothing rather than something misleading.
+            clear_url_state()
+        else:
+            # Keep the URL in sync with current parameter values.
+            write_url_state(active_model, params, scenario_overrides)
 
         typed_params = None
         if not has_input_errors:

--- a/src/epicc/ui/parameters.py
+++ b/src/epicc/ui/parameters.py
@@ -45,7 +45,7 @@ def _build_help_text(spec: Parameter) -> str | None:
     return "\n\n".join(parts) or None
 
 
-def _native_value(value: Any, spec: Parameter) -> Any:
+def native_value(value: Any, spec: Parameter) -> Any:
     """Coerce a value to the native Python type declared by the spec."""
     try:
         if spec.type == "integer":
@@ -80,7 +80,7 @@ def _render_spec_widget(
     help_text = _build_help_text(spec)
 
     if spec.type == "boolean":
-        native_default = _native_value(default_value, spec)
+        native_default = native_value(default_value, spec)
         if widget_key in st.session_state:
             result = container.checkbox(display_label, key=widget_key, help=help_text)
         else:
@@ -91,7 +91,7 @@ def _render_spec_widget(
     elif spec.type in ("integer", "number"):
         is_int = spec.type == "integer"
         coerce = int if is_int else float
-        native_default = coerce(_native_value(default_value, spec))
+        native_default = coerce(native_value(default_value, spec))
 
         kwargs: dict[str, Any] = {
             "label": display_label,
@@ -234,7 +234,7 @@ def _set_param_widget_state(
     params: dict[str, Any],
     spec: Parameter | None = None,
 ) -> None:
-    native = _native_value(value, spec) if spec is not None else str(value)
+    native = native_value(value, spec) if spec is not None else str(value)
     st.session_state[widget_key] = native
     params[param_id] = native
 
@@ -318,8 +318,8 @@ def build_typed_params(
     return model.parameter_model().model_validate(payload)
 
 
-_MAX_SCENARIOS = 10
-_MIN_SCENARIOS = 1
+MAX_SCENARIOS = 10
+MIN_SCENARIOS = 1
 
 
 def _scenario_count_key(model_key: str) -> str:
@@ -353,7 +353,7 @@ def _init_scenario_state(
         vars_dict = scen.vars.model_dump()
         for var_name, spec in specs.items():
             val = vars_dict.get(var_name, spec.default)
-            st.session_state[_scenario_var_key(model_key, i, var_name)] = _native_value(
+            st.session_state[_scenario_var_key(model_key, i, var_name)] = native_value(
                 val, spec
             )
 
@@ -448,7 +448,7 @@ def _render_scenario_editor(
         with btn_col1:
             if st.button(
                 "Add Scenario",
-                disabled=count >= _MAX_SCENARIOS,
+                disabled=count >= MAX_SCENARIOS,
                 key=f"{model_key}__add_scen",
             ):
                 new_idx = count
@@ -461,12 +461,12 @@ def _render_scenario_editor(
                 for var_name, spec in specs.items():
                     st.session_state[
                         _scenario_var_key(model_key, new_idx, var_name)
-                    ] = _native_value(spec.default, spec)
+                    ] = native_value(spec.default, spec)
                 st.rerun()
         with btn_col2:
             if st.button(
                 "Remove Scenario",
-                disabled=count <= _MIN_SCENARIOS,
+                disabled=count <= MIN_SCENARIOS,
                 key=f"{model_key}__rm_scen",
             ):
                 last = count - 1
@@ -497,7 +497,7 @@ def _compute_dirty_state(
         current = st.session_state[widget_key]
         spec = specs.get(key)
         native_default = (
-            _native_value(default_val, spec)
+            native_value(default_val, spec)
             if spec is not None
             else (str(default_val) if default_val is not None else "")
         )
@@ -521,7 +521,7 @@ def _compute_dirty_ids(
         current = st.session_state[widget_key]
         spec = specs.get(key)
         native_default = (
-            _native_value(default_val, spec)
+            native_value(default_val, spec)
             if spec is not None
             else (str(default_val) if default_val is not None else "")
         )
@@ -544,7 +544,7 @@ def _compute_scenario_dirty_state(
             return True
         vars_dict = scen.vars.model_dump()
         for var_name, spec in specs.items():
-            default_val = _native_value(vars_dict.get(var_name, spec.default), spec)
+            default_val = native_value(vars_dict.get(var_name, spec.default), spec)
             if st.session_state.get(_scenario_var_key(model_id, i, var_name)) != default_val:
                 return True
     return False

--- a/src/epicc/ui/parameters.py
+++ b/src/epicc/ui/parameters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
 
 import streamlit as st
@@ -49,14 +50,19 @@ def native_value(value: Any, spec: Parameter) -> Any:
     """Coerce a value to the native Python type declared by the spec."""
     try:
         if spec.type == "integer":
-            return int(float(value))
+            # Ints pass through exactly; anything else goes via Decimal rather
+            # than float, which would round values beyond 2**53 (bool is an int
+            # subclass and keeps its long-standing True -> 1 behaviour).
+            if isinstance(value, int):
+                return int(value)
+            return int(Decimal(str(value)))
         if spec.type == "number":
             return float(value)
         if spec.type == "boolean":
             if isinstance(value, str):
                 return value.lower() not in ("false", "0", "no", "")
             return bool(value)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, InvalidOperation):
         pass
     return str(value)
 

--- a/src/epicc/ui/url_params.py
+++ b/src/epicc/ui/url_params.py
@@ -17,9 +17,11 @@ Grammar:
 - ``scenarios``: comma-separated ordered scenario ids. Emitted only when the
   scenario set or its order differs from the model's defaults.
 
-``model`` and ``scenarios`` are reserved: a parameter with either id is skipped
-rather than written to the URL. Unknown keys are ignored on the way in, so
-Streamlit's own query parameters and stray keys are harmless.
+Some key names are reserved (see :data:`RESERVED_KEYS`): ``model`` and
+``scenarios`` because this grammar uses them, and Streamlit's ``embed`` /
+``embed_options`` because :meth:`st.query_params.from_dict` refuses to set them.
+A parameter with a reserved id is skipped rather than written to the URL.
+Unknown keys are ignored on the way in, so stray keys are harmless.
 
 Values decoded from the URL are coerced, range-clamped, and validated against
 each :class:`~epicc.model.schema.Parameter` spec before they reach a widget.
@@ -34,6 +36,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote, unquote
 
 import streamlit as st
 
@@ -49,19 +52,31 @@ SCENARIOS_KEY = "scenarios"
 _SCEN_PREFIX = "scen."
 _LABEL_FIELD = "label"
 
-#: Query keys that can never denote a model parameter.
-RESERVED_KEYS = frozenset({MODEL_KEY, SCENARIOS_KEY})
+#: Lowercase query keys that can never denote a model parameter. ``embed`` and
+#: ``embed_options`` belong to Streamlit, which raises a ``StreamlitAPIException``
+#: if either is set programmatically (case-insensitively).
+RESERVED_KEYS = frozenset({MODEL_KEY, SCENARIOS_KEY, "embed", "embed_options"})
 
 _TRUE_TOKENS = frozenset({"true", "1", "yes", "on"})
 _FALSE_TOKENS = frozenset({"false", "0", "no", "off"})
+
+#: Longest untrusted fragment echoed back into a warning message.
+_MAX_ECHO_CHARS = 80
+
+
+def is_reserved(key: str) -> bool:
+    """Whether *key* is a query key this grammar or Streamlit claims for itself."""
+    return key.lower() in RESERVED_KEYS
 
 
 @dataclass
 class UrlState:
     """State recovered from the query string.
 
-    ``model_label`` is ``None`` when the slug does not match any known model,
-    in which case only ``warnings`` is meaningful.
+    ``model_label`` is ``None`` when the slug matches no known model, or matches
+    more than one; in that case only ``warnings`` is meaningful. ``resolved``
+    distinguishes the two so the caller can retry later -- a custom model the
+    user has yet to upload may still show up.
     """
 
     slug: str
@@ -69,6 +84,29 @@ class UrlState:
     params: dict[str, Any] = field(default_factory=dict)
     scenarios: list[Scenario] | None = None
     warnings: list[str] = field(default_factory=list)
+
+    @property
+    def resolved(self) -> bool:
+        return self.model_label is not None
+
+
+# --------------------------------------------------------------------------
+# Warning text
+# --------------------------------------------------------------------------
+
+
+def _code(text: object) -> str:
+    """Render untrusted text as an inline code span safe for ``st.warning``.
+
+    Warnings are rendered as Markdown and quote slugs, keys, and raw values
+    straight from the URL. Backticks would close the code span and let the URL
+    inject arbitrary Markdown (an image tag, say) into trusted app chrome, and
+    newlines would end the paragraph, so both are removed before wrapping.
+    """
+    flattened = re.sub(r"\s+", " ", str(text)).replace("`", "").strip()
+    if len(flattened) > _MAX_ECHO_CHARS:
+        flattened = flattened[:_MAX_ECHO_CHARS] + "..."
+    return f"`{flattened}`"
 
 
 # --------------------------------------------------------------------------
@@ -97,11 +135,16 @@ def model_slug(model: BaseSimulationModel) -> str:
 
 def build_slug_registry(
     registry: dict[str, BaseSimulationModel],
-) -> dict[str, str]:
-    """Map slug -> registry label. On a slug collision the first entry wins."""
-    slugs: dict[str, str] = {}
+) -> dict[str, list[str]]:
+    """Map slug -> every registry label claiming it.
+
+    Slugs come from file names, so an uploaded ``measles.yaml`` collides with
+    the built-in model. Collisions are kept rather than silently resolved: a
+    link that could open either calculator should open neither.
+    """
+    slugs: dict[str, list[str]] = {}
     for label, model in registry.items():
-        slugs.setdefault(model_slug(model), label)
+        slugs.setdefault(model_slug(model), []).append(label)
     return slugs
 
 
@@ -127,49 +170,57 @@ def _parse_value(raw: str, spec: Parameter, key: str) -> tuple[Any | None, str |
 
     Returns ``(value, warning_or_None)``. A ``None`` value means the input could
     not be honoured and the accompanying warning explains why.
-    """
-    text = raw.strip()
 
+    Surrounding whitespace is stripped only where it carries no meaning. String
+    and enum values are taken verbatim, so encoding and decoding stay inverses
+    of each other for values that legitimately begin or end with a space.
+    """
     if spec.type in ("integer", "number"):
+        text = raw.strip()
         try:
             number = float(text)
         except (TypeError, ValueError):
-            return None, f"Ignored `{key}={raw}`: expected a number."
+            return None, f"Ignored {_code(f'{key}={raw}')}: expected a number."
         if not math.isfinite(number):
-            return None, f"Ignored `{key}={raw}`: expected a finite number."
+            return None, f"Ignored {_code(f'{key}={raw}')}: expected a finite number."
+        if spec.type == "integer" and number != int(number):
+            return None, f"Ignored {_code(f'{key}={raw}')}: expected a whole number."
 
         cast: Any = int if spec.type == "integer" else float
         value = cast(number)
         if spec.min is not None and value < spec.min:
             value = cast(spec.min)
             return value, (
-                f"`{key}={raw}` is below the minimum for {spec.label}; "
-                f"used {_format_value(value, spec)} instead."
+                f"{_code(f'{key}={raw}')} is below the minimum for "
+                f"{_code(spec.label)}; used {_code(_format_value(value, spec))} instead."
             )
         if spec.max is not None and value > spec.max:
             value = cast(spec.max)
             return value, (
-                f"`{key}={raw}` is above the maximum for {spec.label}; "
-                f"used {_format_value(value, spec)} instead."
+                f"{_code(f'{key}={raw}')} is above the maximum for "
+                f"{_code(spec.label)}; used {_code(_format_value(value, spec))} instead."
             )
         return value, None
 
     if spec.type == "boolean":
-        lowered = text.lower()
+        lowered = raw.strip().lower()
         if lowered in _TRUE_TOKENS:
             return True, None
         if lowered in _FALSE_TOKENS:
             return False, None
-        return None, f"Ignored `{key}={raw}`: expected true or false."
+        return None, f"Ignored {_code(f'{key}={raw}')}: expected true or false."
 
     if spec.type == "enum":
         options = spec.options or {}
-        if text in options:
-            return text, None
+        if raw in options:
+            return raw, None
         allowed = ", ".join(options) or "(none)"
-        return None, f"Ignored `{key}={raw}`: {spec.label} accepts one of {allowed}."
+        return None, (
+            f"Ignored {_code(f'{key}={raw}')}: {_code(spec.label)} accepts one of "
+            f"{_code(allowed)}."
+        )
 
-    return text, None
+    return raw, None
 
 
 # --------------------------------------------------------------------------
@@ -181,19 +232,16 @@ def encode_state(
     model: BaseSimulationModel,
     params: dict[str, Any],
     scenarios: list[Scenario] | None = None,
-    slug: str | None = None,
 ) -> dict[str, str]:
     """Build the query mapping for the current state of *model*.
 
-    Only values that differ from the model's defaults are included. Pass *slug*
-    to name a different model in the link than the one supplying the specs --
-    the editor preview does this so its link still reopens the saved model.
+    Only values that differ from the model's defaults are included.
     """
-    query: dict[str, str] = {MODEL_KEY: slug or model_slug(model)}
+    query: dict[str, str] = {MODEL_KEY: model_slug(model)}
 
     specs: dict[str, Parameter] = model.parameter_specs or {}
     for param_id, spec in specs.items():
-        if param_id in RESERVED_KEYS or param_id not in params:
+        if is_reserved(param_id) or param_id not in params:
             continue
         current = native_value(params[param_id], spec)
         default = native_value(spec.default, spec)
@@ -218,7 +266,7 @@ def _encode_scenarios(
 
     query: dict[str, str] = {}
     if [scen.id for scen in scenarios] != [scen.id for scen in defaults]:
-        query[SCENARIOS_KEY] = ",".join(scen.id for scen in scenarios)
+        query[SCENARIOS_KEY] = ",".join(_quote_id(scen.id) for scen in scenarios)
 
     for index, scen in enumerate(scenarios):
         base = default_by_id.get(scen.id)
@@ -238,6 +286,16 @@ def _encode_scenarios(
             query[f"{_SCEN_PREFIX}{scen.id}.{var_name}"] = _format_value(current, spec)
 
     return query
+
+
+def _quote_id(scen_id: str) -> str:
+    """Percent-encode a scenario id for the comma-separated ``scenarios`` list.
+
+    Ordinary ids (``22_cases``) pass through untouched; only ids containing a
+    comma -- which the schema permits -- are escaped, so the list stays
+    unambiguous without becoming unreadable in the common case.
+    """
+    return quote(scen_id, safe="")
 
 
 def _fallback_label(index: int) -> str:
@@ -267,7 +325,7 @@ def decode_state(
 
     specs: dict[str, Parameter] = model.parameter_specs or {}
     for param_id, spec in specs.items():
-        if param_id in RESERVED_KEYS or param_id not in query:
+        if is_reserved(param_id) or param_id not in query:
             continue
         value, warning = _parse_value(query[param_id], spec, param_id)
         if warning is not None:
@@ -280,12 +338,23 @@ def decode_state(
     for var_name, spec in (model.scenario_parameter_specs or {}).items():
         if var_name in query and var_name not in specs:
             warnings.append(
-                f"Ignored `{var_name}={query[var_name]}`: {spec.label} is set per "
-                f"scenario, as `{_SCEN_PREFIX}<scenario>.{var_name}`."
+                f"Ignored {_code(f'{var_name}={query[var_name]}')}: {_code(spec.label)} "
+                f"is set per scenario, as {_code(f'{_SCEN_PREFIX}<scenario>.{var_name}')}."
             )
 
     scenarios = _decode_scenarios(model, query, warnings)
     return values, scenarios, warnings
+
+
+def _split_scen_key(key: str) -> tuple[str, str] | None:
+    """Split ``scen.<id>.<field>`` into ``(id, field)``.
+
+    Uses the *last* dot as the separator, so scenario ids containing dots work.
+    """
+    scen_id, separator, scen_field = key[len(_SCEN_PREFIX) :].rpartition(".")
+    if not separator or not scen_id:
+        return None
+    return scen_id, scen_field
 
 
 def _decode_scenarios(
@@ -305,26 +374,41 @@ def _decode_scenarios(
 
     raw_order = query.get(SCENARIOS_KEY)
     if raw_order is not None:
-        requested = _unique(part.strip() for part in raw_order.split(","))
+        requested = _unique(unquote(part.strip()) for part in raw_order.split(","))
         if not requested:
-            warnings.append(f"Ignored `{SCENARIOS_KEY}={raw_order}`: no scenario ids.")
+            warnings.append(
+                f"Ignored {_code(f'{SCENARIOS_KEY}={raw_order}')}: no scenario ids."
+            )
         else:
             if len(requested) > MAX_SCENARIOS:
                 warnings.append(
-                    f"`{SCENARIOS_KEY}` listed {len(requested)} scenarios; "
+                    f"{_code(SCENARIOS_KEY)} listed {len(requested)} scenarios; "
                     f"only the first {MAX_SCENARIOS} were used."
                 )
                 requested = requested[:MAX_SCENARIOS]
             order = requested
             touched = True
 
-    known = set(order)
+    known_ids = set(order)
+    known_fields = {_LABEL_FIELD} | set(scen_specs)
     for key in query:
         if not key.startswith(_SCEN_PREFIX):
             continue
-        scen_id = key[len(_SCEN_PREFIX) :].rsplit(".", 1)[0]
-        if scen_id and scen_id not in known:
-            warnings.append(f"Ignored `{key}`: no scenario with id `{scen_id}`.")
+        parts = _split_scen_key(key)
+        if parts is None:
+            warnings.append(
+                f"Ignored {_code(key)}: expected "
+                f"{_code(f'{_SCEN_PREFIX}<scenario>.<field>')}."
+            )
+            continue
+        scen_id, scen_field = parts
+        if scen_id not in known_ids:
+            warnings.append(f"Ignored {_code(key)}: no scenario with id {_code(scen_id)}.")
+        elif scen_field not in known_fields:
+            allowed = ", ".join(sorted(known_fields))
+            warnings.append(
+                f"Ignored {_code(key)}: scenarios accept {_code(allowed)}."
+            )
 
     scenarios: list[Scenario] = []
     for index, scen_id in enumerate(order):
@@ -383,16 +467,25 @@ def read_url_state(registry: dict[str, BaseSimulationModel]) -> UrlState | None:
     if not slug:
         return None
 
-    label = build_slug_registry(registry).get(slug)
-    if label is None:
+    candidates = build_slug_registry(registry).get(slug, [])
+    if len(candidates) > 1:
         return UrlState(
             slug=slug,
             warnings=[
-                f"The link refers to a model named `{slug}`, which is not "
-                "available here. Pick a model to continue."
+                f"The link refers to {_code(slug)}, but more than one loaded model "
+                "goes by that name. Pick the one you meant from the model list."
+            ],
+        )
+    if not candidates:
+        return UrlState(
+            slug=slug,
+            warnings=[
+                f"The link refers to a model named {_code(slug)}, which isn't "
+                "loaded here. Load that model and the link's values will be applied."
             ],
         )
 
+    label = candidates[0]
     values, scenarios, warnings = decode_state(registry[label], query)
     return UrlState(
         slug=slug,
@@ -407,11 +500,19 @@ def write_url_state(
     model: BaseSimulationModel,
     params: dict[str, Any],
     scenarios: list[Scenario] | None = None,
-    slug: str | None = None,
 ) -> None:
     """Replace the query string with the current state of *model*.
 
     Uses ``from_dict`` so parameters returned to their defaults disappear from
     the URL instead of lingering.
     """
-    st.query_params.from_dict(encode_state(model, params, scenarios, slug))
+    st.query_params.from_dict(encode_state(model, params, scenarios))
+
+
+def clear_url_state() -> None:
+    """Drop the state from the URL, leaving Streamlit's own keys in place.
+
+    Used when the on-screen state cannot honestly be expressed as a link, so
+    that no stale or misleading permalink is left behind.
+    """
+    st.query_params.clear()

--- a/src/epicc/ui/url_params.py
+++ b/src/epicc/ui/url_params.py
@@ -1,96 +1,417 @@
-"""Encode and decode model parameters to/from URL query parameters.
+"""Encode and decode model parameters to/from human-readable URL query parameters.
 
-The simulator state is stored as a base64url-encoded JSON payload in a single
-``params`` query parameter. The payload contains these keys:
+The address bar *is* the permalink, so the query string is written to be read,
+copied into a document, and hand-edited:
 
-- ``model``: the human-readable model label
-- ``values``: the flat parameter dictionary
-- ``scenarios``: the optional scenario definitions, labels, and values
+    ?model=measles&vaccination_rate=0.9&scen.22_cases.label=Small+outbreak
 
-This keeps the URL compact and avoids key collisions with Streamlit internals.
+Grammar:
+
+- ``model``: the model slug (the YAML file stem, e.g. ``measles``). Required;
+  without it there is nothing to restore.
+- ``<param_id>``: an equation-context parameter, keyed by its YAML id. Emitted
+  only when the current value differs from the model's default, so a link shows
+  exactly what the sender changed and nothing else.
+- ``scen.<scenario_id>.<var>``: a scenario-variable override.
+- ``scen.<scenario_id>.label``: a scenario label override.
+- ``scenarios``: comma-separated ordered scenario ids. Emitted only when the
+  scenario set or its order differs from the model's defaults.
+
+``model`` and ``scenarios`` are reserved: a parameter with either id is skipped
+rather than written to the URL. Unknown keys are ignored on the way in, so
+Streamlit's own query parameters and stray keys are harmless.
+
+Values decoded from the URL are coerced, range-clamped, and validated against
+each :class:`~epicc.model.schema.Parameter` spec before they reach a widget.
+Anything that cannot be honoured is dropped and reported through the warnings
+list rather than failing silently -- hand-edited URLs make typos likely.
 """
 
 from __future__ import annotations
 
-import base64
-import json
-from typing import Any
+import math
+import re
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any
 
 import streamlit as st
 
-from epicc.model.schema import Scenario
+from epicc.model.schema import Scenario, ScenarioVars
+from epicc.ui.parameters import MAX_SCENARIOS, native_value
 
-_QUERY_KEY = "params"
+if TYPE_CHECKING:
+    from epicc.model.base import BaseSimulationModel
+    from epicc.model.schema import Parameter
+
+MODEL_KEY = "model"
+SCENARIOS_KEY = "scenarios"
+_SCEN_PREFIX = "scen."
+_LABEL_FIELD = "label"
+
+#: Query keys that can never denote a model parameter.
+RESERVED_KEYS = frozenset({MODEL_KEY, SCENARIOS_KEY})
+
+_TRUE_TOKENS = frozenset({"true", "1", "yes", "on"})
+_FALSE_TOKENS = frozenset({"false", "0", "no", "off"})
 
 
-def encode_params(
-    model_label: str,
+@dataclass
+class UrlState:
+    """State recovered from the query string.
+
+    ``model_label`` is ``None`` when the slug does not match any known model,
+    in which case only ``warnings`` is meaningful.
+    """
+
+    slug: str
+    model_label: str | None = None
+    params: dict[str, Any] = field(default_factory=dict)
+    scenarios: list[Scenario] | None = None
+    warnings: list[str] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------
+# Slugs
+# --------------------------------------------------------------------------
+
+
+def _slugify(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")
+
+
+def model_slug(model: BaseSimulationModel) -> str:
+    """Return the short, URL-friendly identifier for *model*.
+
+    Built-in models are loaded from ``epicc.model.models/<slug>.yaml``, so the
+    file stem is the natural slug. Anything without a source path falls back to
+    a slugified title.
+    """
+    source = model.get_source_path()
+    if source:
+        stem = _slugify(PurePosixPath(source).stem)
+        if stem:
+            return stem
+    return _slugify(model.human_name()) or "model"
+
+
+def build_slug_registry(
+    registry: dict[str, BaseSimulationModel],
+) -> dict[str, str]:
+    """Map slug -> registry label. On a slug collision the first entry wins."""
+    slugs: dict[str, str] = {}
+    for label, model in registry.items():
+        slugs.setdefault(model_slug(model), label)
+    return slugs
+
+
+# --------------------------------------------------------------------------
+# Value formatting and parsing
+# --------------------------------------------------------------------------
+
+
+def _format_value(value: Any, spec: Parameter) -> str:
+    """Render a native value as the shortest string that parses back to it."""
+    if spec.type == "boolean":
+        return "true" if value else "false"
+    if spec.type == "integer":
+        return str(int(value))
+    if spec.type == "number":
+        text = repr(float(value))
+        return text[:-2] if text.endswith(".0") else text
+    return str(value)
+
+
+def _parse_value(raw: str, spec: Parameter, key: str) -> tuple[Any | None, str | None]:
+    """Parse *raw* into a native value for *spec*.
+
+    Returns ``(value, warning_or_None)``. A ``None`` value means the input could
+    not be honoured and the accompanying warning explains why.
+    """
+    text = raw.strip()
+
+    if spec.type in ("integer", "number"):
+        try:
+            number = float(text)
+        except (TypeError, ValueError):
+            return None, f"Ignored `{key}={raw}`: expected a number."
+        if not math.isfinite(number):
+            return None, f"Ignored `{key}={raw}`: expected a finite number."
+
+        cast: Any = int if spec.type == "integer" else float
+        value = cast(number)
+        if spec.min is not None and value < spec.min:
+            value = cast(spec.min)
+            return value, (
+                f"`{key}={raw}` is below the minimum for {spec.label}; "
+                f"used {_format_value(value, spec)} instead."
+            )
+        if spec.max is not None and value > spec.max:
+            value = cast(spec.max)
+            return value, (
+                f"`{key}={raw}` is above the maximum for {spec.label}; "
+                f"used {_format_value(value, spec)} instead."
+            )
+        return value, None
+
+    if spec.type == "boolean":
+        lowered = text.lower()
+        if lowered in _TRUE_TOKENS:
+            return True, None
+        if lowered in _FALSE_TOKENS:
+            return False, None
+        return None, f"Ignored `{key}={raw}`: expected true or false."
+
+    if spec.type == "enum":
+        options = spec.options or {}
+        if text in options:
+            return text, None
+        allowed = ", ".join(options) or "(none)"
+        return None, f"Ignored `{key}={raw}`: {spec.label} accepts one of {allowed}."
+
+    return text, None
+
+
+# --------------------------------------------------------------------------
+# Encoding
+# --------------------------------------------------------------------------
+
+
+def encode_state(
+    model: BaseSimulationModel,
     params: dict[str, Any],
     scenarios: list[Scenario] | None = None,
-) -> str:
-    """Return a base64url-encoded JSON string for embedding in the URL."""
-    payload: dict[str, Any] = {"model": model_label, "values": params}
-    if scenarios is not None:
-        payload["scenarios"] = [
-            scenario.model_dump(mode="json") for scenario in scenarios
-        ]
-    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True)
-    return base64.urlsafe_b64encode(raw.encode()).decode().rstrip("=")
+    slug: str | None = None,
+) -> dict[str, str]:
+    """Build the query mapping for the current state of *model*.
 
-
-def decode_params(
-    encoded: str,
-) -> tuple[str, dict[str, Any], list[Scenario] | None] | None:
-    """Decode a URL param string back into model, parameters, and scenarios.
-
-    Returns ``None`` if decoding fails.
+    Only values that differ from the model's defaults are included. Pass *slug*
+    to name a different model in the link than the one supplying the specs --
+    the editor preview does this so its link still reopens the saved model.
     """
-    try:
-        # Re-pad base64
-        padded = encoded + "=" * (-len(encoded) % 4)
-        raw = base64.urlsafe_b64decode(padded).decode()
-        payload = json.loads(raw)
-        model = payload["model"]
-        values = payload["values"]
-        if not isinstance(model, str) or not isinstance(values, dict):
-            return None
-        scenario_data = payload.get("scenarios")
-        if scenario_data is None:
-            scenarios = None
-        elif isinstance(scenario_data, list):
-            scenarios = [Scenario.model_validate(item) for item in scenario_data]
+    query: dict[str, str] = {MODEL_KEY: slug or model_slug(model)}
+
+    specs: dict[str, Parameter] = model.parameter_specs or {}
+    for param_id, spec in specs.items():
+        if param_id in RESERVED_KEYS or param_id not in params:
+            continue
+        current = native_value(params[param_id], spec)
+        default = native_value(spec.default, spec)
+        if current == default:
+            continue
+        query[param_id] = _format_value(current, spec)
+
+    query.update(_encode_scenarios(model, scenarios))
+    return query
+
+
+def _encode_scenarios(
+    model: BaseSimulationModel,
+    scenarios: list[Scenario] | None,
+) -> dict[str, str]:
+    if not scenarios:
+        return {}
+
+    defaults = model.default_scenarios or []
+    scen_specs: dict[str, Parameter] = model.scenario_parameter_specs or {}
+    default_by_id = {scen.id: scen for scen in defaults}
+
+    query: dict[str, str] = {}
+    if [scen.id for scen in scenarios] != [scen.id for scen in defaults]:
+        query[SCENARIOS_KEY] = ",".join(scen.id for scen in scenarios)
+
+    for index, scen in enumerate(scenarios):
+        base = default_by_id.get(scen.id)
+        base_label = base.label if base is not None else _fallback_label(index)
+        if scen.label != base_label:
+            query[f"{_SCEN_PREFIX}{scen.id}.{_LABEL_FIELD}"] = scen.label
+
+        base_vars = base.vars.model_dump() if base is not None else {}
+        current_vars = scen.vars.model_dump()
+        for var_name, spec in scen_specs.items():
+            if var_name not in current_vars:
+                continue
+            current = native_value(current_vars[var_name], spec)
+            default = native_value(base_vars.get(var_name, spec.default), spec)
+            if current == default:
+                continue
+            query[f"{_SCEN_PREFIX}{scen.id}.{var_name}"] = _format_value(current, spec)
+
+    return query
+
+
+def _fallback_label(index: int) -> str:
+    """Label used for a scenario with no default counterpart.
+
+    Matches the scenario editor's own placeholder so a round trip is stable.
+    """
+    return f"Scenario {index + 1}"
+
+
+# --------------------------------------------------------------------------
+# Decoding
+# --------------------------------------------------------------------------
+
+
+def decode_state(
+    model: BaseSimulationModel,
+    query: dict[str, str],
+) -> tuple[dict[str, Any], list[Scenario] | None, list[str]]:
+    """Decode *query* against *model*.
+
+    Returns ``(param_overrides, scenarios, warnings)``. ``scenarios`` is ``None``
+    when the query says nothing about scenarios, so the model's defaults stand.
+    """
+    warnings: list[str] = []
+    values: dict[str, Any] = {}
+
+    specs: dict[str, Parameter] = model.parameter_specs or {}
+    for param_id, spec in specs.items():
+        if param_id in RESERVED_KEYS or param_id not in query:
+            continue
+        value, warning = _parse_value(query[param_id], spec, param_id)
+        if warning is not None:
+            warnings.append(warning)
+        if value is not None:
+            values[param_id] = value
+
+    # A scenario variable at the top level is a plausible hand-editing mistake:
+    # it belongs under a scenario id, so say so rather than ignoring it.
+    for var_name, spec in (model.scenario_parameter_specs or {}).items():
+        if var_name in query and var_name not in specs:
+            warnings.append(
+                f"Ignored `{var_name}={query[var_name]}`: {spec.label} is set per "
+                f"scenario, as `{_SCEN_PREFIX}<scenario>.{var_name}`."
+            )
+
+    scenarios = _decode_scenarios(model, query, warnings)
+    return values, scenarios, warnings
+
+
+def _decode_scenarios(
+    model: BaseSimulationModel,
+    query: dict[str, str],
+    warnings: list[str],
+) -> list[Scenario] | None:
+    defaults = model.default_scenarios
+    if not defaults:
+        return None
+
+    scen_specs: dict[str, Parameter] = model.scenario_parameter_specs or {}
+    default_by_id = {scen.id: scen for scen in defaults}
+
+    order = [scen.id for scen in defaults]
+    touched = False
+
+    raw_order = query.get(SCENARIOS_KEY)
+    if raw_order is not None:
+        requested = _unique(part.strip() for part in raw_order.split(","))
+        if not requested:
+            warnings.append(f"Ignored `{SCENARIOS_KEY}={raw_order}`: no scenario ids.")
         else:
-            return None
-        return model, values, scenarios
-    except Exception:  # noqa: BLE001
+            if len(requested) > MAX_SCENARIOS:
+                warnings.append(
+                    f"`{SCENARIOS_KEY}` listed {len(requested)} scenarios; "
+                    f"only the first {MAX_SCENARIOS} were used."
+                )
+                requested = requested[:MAX_SCENARIOS]
+            order = requested
+            touched = True
+
+    known = set(order)
+    for key in query:
+        if not key.startswith(_SCEN_PREFIX):
+            continue
+        scen_id = key[len(_SCEN_PREFIX) :].rsplit(".", 1)[0]
+        if scen_id and scen_id not in known:
+            warnings.append(f"Ignored `{key}`: no scenario with id `{scen_id}`.")
+
+    scenarios: list[Scenario] = []
+    for index, scen_id in enumerate(order):
+        base = default_by_id.get(scen_id)
+        label = base.label if base is not None else _fallback_label(index)
+        base_vars = base.vars.model_dump() if base is not None else {}
+
+        var_values: dict[str, Any] = {
+            var_name: native_value(base_vars.get(var_name, spec.default), spec)
+            for var_name, spec in scen_specs.items()
+        }
+
+        label_key = f"{_SCEN_PREFIX}{scen_id}.{_LABEL_FIELD}"
+        if label_key in query:
+            label = query[label_key]
+            touched = True
+
+        for var_name, spec in scen_specs.items():
+            key = f"{_SCEN_PREFIX}{scen_id}.{var_name}"
+            if key not in query:
+                continue
+            value, warning = _parse_value(query[key], spec, key)
+            if warning is not None:
+                warnings.append(warning)
+            if value is not None:
+                var_values[var_name] = value
+                touched = True
+
+        scenarios.append(
+            Scenario(id=scen_id, label=label, vars=ScenarioVars(**var_values))
+        )
+
+    return scenarios if touched else None
+
+
+def _unique(items: Any) -> list[str]:
+    """Drop blanks and duplicates while preserving order."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item and item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+# --------------------------------------------------------------------------
+# Streamlit glue
+# --------------------------------------------------------------------------
+
+
+def read_url_state(registry: dict[str, BaseSimulationModel]) -> UrlState | None:
+    """Read the current query string. Returns ``None`` when no model is named."""
+    query = st.query_params.to_dict()
+    slug = query.get(MODEL_KEY, "").strip()
+    if not slug:
         return None
 
+    label = build_slug_registry(registry).get(slug)
+    if label is None:
+        return UrlState(
+            slug=slug,
+            warnings=[
+                f"The link refers to a model named `{slug}`, which is not "
+                "available here. Pick a model to continue."
+            ],
+        )
 
-def read_url_params() -> tuple[str, dict[str, Any], list[Scenario] | None] | None:
-    """Read and decode parameters from the current URL query string.
-
-    Returns ``(model_label, param_dict, scenarios)`` or ``None`` if no valid
-    payload is found. Parameter-only links created by older versions return
-    ``None`` for scenarios.
-    """
-    qp = st.query_params
-    encoded = qp.get(_QUERY_KEY)
-    if not encoded:
-        return None
-    return decode_params(encoded)
+    values, scenarios, warnings = decode_state(registry[label], query)
+    return UrlState(
+        slug=slug,
+        model_label=label,
+        params=values,
+        scenarios=scenarios,
+        warnings=warnings,
+    )
 
 
-def write_url_params(
-    model_label: str,
+def write_url_state(
+    model: BaseSimulationModel,
     params: dict[str, Any],
     scenarios: list[Scenario] | None = None,
+    slug: str | None = None,
 ) -> None:
-    """Update the browser URL with the current parameter state."""
-    encoded = encode_params(model_label, params, scenarios)
-    st.query_params[_QUERY_KEY] = encoded
+    """Replace the query string with the current state of *model*.
 
-
-def clear_url_params() -> None:
-    """Remove parameter payload from the URL."""
-    if _QUERY_KEY in st.query_params:
-        del st.query_params[_QUERY_KEY]
+    Uses ``from_dict`` so parameters returned to their defaults disappear from
+    the URL instead of lingering.
+    """
+    st.query_params.from_dict(encode_state(model, params, scenarios, slug))

--- a/src/epicc/ui/url_params.py
+++ b/src/epicc/ui/url_params.py
@@ -3,24 +3,24 @@
 The address bar *is* the permalink, so the query string is written to be read,
 copied into a document, and hand-edited:
 
-    ?model=measles&vaccination_rate=0.9&scen.22_cases.label=Small+outbreak
+    ?model=measles&param.vaccination_rate=0.9&scen.22_cases.label=Small+outbreak
 
 Grammar:
 
 - ``model``: the model slug (the YAML file stem, e.g. ``measles``). Required;
   without it there is nothing to restore.
-- ``<param_id>``: an equation-context parameter, keyed by its YAML id. Emitted
-  only when the current value differs from the model's default, so a link shows
-  exactly what the sender changed and nothing else.
+- ``param.<param_id>``: an equation-context parameter, keyed by its YAML id.
+  Emitted only when the current value differs from the model's default, so a
+  link shows exactly what the sender changed and nothing else.
 - ``scen.<scenario_id>.<var>``: a scenario-variable override.
 - ``scen.<scenario_id>.label``: a scenario label override.
 - ``scenarios``: comma-separated ordered scenario ids. Emitted only when the
   scenario set or its order differs from the model's defaults.
 
-Some key names are reserved (see :data:`RESERVED_KEYS`): ``model`` and
+Some top-level key names are reserved (see :data:`RESERVED_KEYS`): ``model`` and
 ``scenarios`` because this grammar uses them, and Streamlit's ``embed`` /
 ``embed_options`` because :meth:`st.query_params.from_dict` refuses to set them.
-A parameter with a reserved id is skipped rather than written to the URL.
+The ``param.`` namespace keeps parameter ids from colliding with any of them.
 Unknown keys are ignored on the way in, so stray keys are harmless.
 
 Values decoded from the URL are coerced, range-clamped, and validated against
@@ -34,6 +34,7 @@ from __future__ import annotations
 import math
 import re
 from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote, unquote
@@ -49,8 +50,15 @@ if TYPE_CHECKING:
 
 MODEL_KEY = "model"
 SCENARIOS_KEY = "scenarios"
+_PARAM_PREFIX = "param."
 _SCEN_PREFIX = "scen."
 _LABEL_FIELD = "label"
+_EMPTY_SCENARIO_ID_TOKEN = "!"
+
+# Streamlit number inputs serialize through JavaScript and cannot preserve
+# integers outside this range.
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_MIN_SAFE_INTEGER = -_MAX_SAFE_INTEGER
 
 #: Lowercase query keys that can never denote a model parameter. ``embed`` and
 #: ``embed_options`` belong to Streamlit, which raises a ``StreamlitAPIException``
@@ -67,6 +75,11 @@ _MAX_ECHO_CHARS = 80
 def is_reserved(key: str) -> bool:
     """Whether *key* is a query key this grammar or Streamlit claims for itself."""
     return key.lower() in RESERVED_KEYS
+
+
+def _param_key(param_id: str) -> str:
+    """Return the namespaced query key for an equation parameter id."""
+    return f"{_PARAM_PREFIX}{param_id}"
 
 
 @dataclass
@@ -175,7 +188,47 @@ def _parse_value(raw: str, spec: Parameter, key: str) -> tuple[Any | None, str |
     and enum values are taken verbatim, so encoding and decoding stay inverses
     of each other for values that legitimately begin or end with a space.
     """
-    if spec.type in ("integer", "number"):
+    if spec.type == "integer":
+        text = raw.strip()
+        try:
+            exact = Decimal(text)
+        except (InvalidOperation, TypeError, ValueError):
+            return None, f"Ignored {_code(f'{key}={raw}')}: expected a number."
+        if not exact.is_finite():
+            return None, f"Ignored {_code(f'{key}={raw}')}: expected a finite number."
+        if exact != exact.to_integral_value():
+            return None, f"Ignored {_code(f'{key}={raw}')}: expected a whole number."
+
+        clamped: str | None = None
+        if spec.min is not None and exact < Decimal(str(spec.min)):
+            exact = Decimal(int(spec.min))
+            clamped = "below"
+        elif spec.max is not None and exact > Decimal(str(spec.max)):
+            exact = Decimal(int(spec.max))
+            clamped = "above"
+
+        if exact < _MIN_SAFE_INTEGER or exact > _MAX_SAFE_INTEGER:
+            return None, (
+                f"Ignored {_code(f'{key}={raw}')}: whole numbers must be between "
+                f"{_code(_MIN_SAFE_INTEGER)} and {_code(_MAX_SAFE_INTEGER)}."
+            )
+
+        int_value = int(exact)
+        if clamped == "below":
+            return int_value, (
+                f"{_code(f'{key}={raw}')} is below the minimum for "
+                f"{_code(spec.label)}; used "
+                f"{_code(_format_value(int_value, spec))} instead."
+            )
+        if clamped == "above":
+            return int_value, (
+                f"{_code(f'{key}={raw}')} is above the maximum for "
+                f"{_code(spec.label)}; used "
+                f"{_code(_format_value(int_value, spec))} instead."
+            )
+        return int_value, None
+
+    if spec.type == "number":
         text = raw.strip()
         try:
             number = float(text)
@@ -183,24 +236,19 @@ def _parse_value(raw: str, spec: Parameter, key: str) -> tuple[Any | None, str |
             return None, f"Ignored {_code(f'{key}={raw}')}: expected a number."
         if not math.isfinite(number):
             return None, f"Ignored {_code(f'{key}={raw}')}: expected a finite number."
-        if spec.type == "integer" and number != int(number):
-            return None, f"Ignored {_code(f'{key}={raw}')}: expected a whole number."
-
-        cast: Any = int if spec.type == "integer" else float
-        value = cast(number)
-        if spec.min is not None and value < spec.min:
-            value = cast(spec.min)
-            return value, (
+        if spec.min is not None and number < spec.min:
+            number = float(spec.min)
+            return number, (
                 f"{_code(f'{key}={raw}')} is below the minimum for "
-                f"{_code(spec.label)}; used {_code(_format_value(value, spec))} instead."
+                f"{_code(spec.label)}; used {_code(_format_value(number, spec))} instead."
             )
-        if spec.max is not None and value > spec.max:
-            value = cast(spec.max)
-            return value, (
+        if spec.max is not None and number > spec.max:
+            number = float(spec.max)
+            return number, (
                 f"{_code(f'{key}={raw}')} is above the maximum for "
-                f"{_code(spec.label)}; used {_code(_format_value(value, spec))} instead."
+                f"{_code(spec.label)}; used {_code(_format_value(number, spec))} instead."
             )
-        return value, None
+        return number, None
 
     if spec.type == "boolean":
         lowered = raw.strip().lower()
@@ -241,13 +289,13 @@ def encode_state(
 
     specs: dict[str, Parameter] = model.parameter_specs or {}
     for param_id, spec in specs.items():
-        if is_reserved(param_id) or param_id not in params:
+        if param_id not in params:
             continue
         current = native_value(params[param_id], spec)
         default = native_value(spec.default, spec)
         if current == default:
             continue
-        query[param_id] = _format_value(current, spec)
+        query[_param_key(param_id)] = _format_value(current, spec)
 
     query.update(_encode_scenarios(model, scenarios))
     return query
@@ -291,11 +339,20 @@ def _encode_scenarios(
 def _quote_id(scen_id: str) -> str:
     """Percent-encode a scenario id for the comma-separated ``scenarios`` list.
 
-    Ordinary ids (``22_cases``) pass through untouched; only ids containing a
-    comma -- which the schema permits -- are escaped, so the list stays
-    unambiguous without becoming unreadable in the common case.
+    Ordinary ids (``22_cases``) pass through untouched. Delimiters are escaped,
+    and an empty id uses a token that cannot collide with a literal id, so the
+    list stays unambiguous without becoming unreadable in the common case.
     """
+    if scen_id == "":
+        return _EMPTY_SCENARIO_ID_TOKEN
     return quote(scen_id, safe="")
+
+
+def _unquote_id(token: str) -> str:
+    """Reverse :func:`_quote_id` without conflating empty and literal ids."""
+    if token == _EMPTY_SCENARIO_ID_TOKEN:
+        return ""
+    return unquote(token)
 
 
 def _fallback_label(index: int) -> str:
@@ -325,21 +382,32 @@ def decode_state(
 
     specs: dict[str, Parameter] = model.parameter_specs or {}
     for param_id, spec in specs.items():
-        if is_reserved(param_id) or param_id not in query:
+        key = _param_key(param_id)
+        if key not in query:
             continue
-        value, warning = _parse_value(query[param_id], spec, param_id)
+        value, warning = _parse_value(query[key], spec, key)
         if warning is not None:
             warnings.append(warning)
         if value is not None:
             values[param_id] = value
 
-    # A scenario variable at the top level is a plausible hand-editing mistake:
-    # it belongs under a scenario id, so say so rather than ignoring it.
+    # A scenario variable under param. is a plausible hand-editing mistake: it
+    # belongs under a scenario id, so say so rather than ignoring it.
     for var_name, spec in (model.scenario_parameter_specs or {}).items():
-        if var_name in query and var_name not in specs:
+        key = _param_key(var_name)
+        if key in query and var_name not in specs:
             warnings.append(
-                f"Ignored {_code(f'{var_name}={query[var_name]}')}: {_code(spec.label)} "
+                f"Ignored {_code(f'{key}={query[key]}')}: {_code(spec.label)} "
                 f"is set per scenario, as {_code(f'{_SCEN_PREFIX}<scenario>.{var_name}')}."
+            )
+
+    # So is dropping the namespace entirely. Bare parameter names look right and
+    # would otherwise be ignored as unknown keys, leaving defaults in place.
+    for param_id in _unique([*specs, *(model.scenario_parameter_specs or {})]):
+        if param_id in query and not is_reserved(param_id):
+            warnings.append(
+                f"Ignored {_code(f'{param_id}={query[param_id]}')}: parameters need "
+                f"the {_code(_PARAM_PREFIX)} prefix, as {_code(_param_key(param_id))}."
             )
 
     scenarios = _decode_scenarios(model, query, warnings)
@@ -352,7 +420,7 @@ def _split_scen_key(key: str) -> tuple[str, str] | None:
     Uses the *last* dot as the separator, so scenario ids containing dots work.
     """
     scen_id, separator, scen_field = key[len(_SCEN_PREFIX) :].rpartition(".")
-    if not separator or not scen_id:
+    if not separator:
         return None
     return scen_id, scen_field
 
@@ -374,7 +442,8 @@ def _decode_scenarios(
 
     raw_order = query.get(SCENARIOS_KEY)
     if raw_order is not None:
-        requested = _unique(unquote(part.strip()) for part in raw_order.split(","))
+        tokens = [part.strip() for part in raw_order.split(",") if part.strip()]
+        requested = _unique(_unquote_id(token) for token in tokens)
         if not requested:
             warnings.append(
                 f"Ignored {_code(f'{SCENARIOS_KEY}={raw_order}')}: no scenario ids."
@@ -445,11 +514,11 @@ def _decode_scenarios(
 
 
 def _unique(items: Any) -> list[str]:
-    """Drop blanks and duplicates while preserving order."""
+    """Drop duplicates while preserving order."""
     seen: set[str] = set()
     result: list[str] = []
     for item in items:
-        if item and item not in seen:
+        if item not in seen:
             seen.add(item)
             result.append(item)
     return result
@@ -460,15 +529,21 @@ def _unique(items: Any) -> list[str]:
 # --------------------------------------------------------------------------
 
 
-def read_url_state(registry: dict[str, BaseSimulationModel]) -> UrlState | None:
-    """Read the current query string. Returns ``None`` when no model is named."""
+def read_url_state(
+    registry: dict[str, BaseSimulationModel],
+    *,
+    preferred_label: str | None = None,
+) -> UrlState | None:
+    """Read the query string, using an explicit selection to break slug ties."""
     query = st.query_params.to_dict()
     slug = query.get(MODEL_KEY, "").strip()
     if not slug:
         return None
 
     candidates = build_slug_registry(registry).get(slug, [])
-    if len(candidates) > 1:
+    if preferred_label is not None and preferred_label in candidates:
+        label = preferred_label
+    elif len(candidates) > 1:
         return UrlState(
             slug=slug,
             warnings=[
@@ -476,7 +551,7 @@ def read_url_state(registry: dict[str, BaseSimulationModel]) -> UrlState | None:
                 "goes by that name. Pick the one you meant from the model list."
             ],
         )
-    if not candidates:
+    elif not candidates:
         return UrlState(
             slug=slug,
             warnings=[
@@ -484,8 +559,9 @@ def read_url_state(registry: dict[str, BaseSimulationModel]) -> UrlState | None:
                 "loaded here. Load that model and the link's values will be applied."
             ],
         )
+    else:
+        label = candidates[0]
 
-    label = candidates[0]
     values, scenarios, warnings = decode_state(registry[label], query)
     return UrlState(
         slug=slug,

--- a/tests/epicc/test_url_params.py
+++ b/tests/epicc/test_url_params.py
@@ -1,104 +1,399 @@
-"""Tests for epicc.ui.url_params encode/decode logic."""
+"""Tests for epicc.ui.url_params human-readable query-string encoding."""
 
-import base64
-import json
+from typing import Any
 
+import pytest
 from streamlit.testing.v1 import AppTest
 
+from epicc.model.base import BaseSimulationModel
+from epicc.model.models import get_all_models
 from epicc.model.schema import Scenario, ScenarioVars
-from epicc.ui.url_params import decode_params, encode_params
+from epicc.ui.url_params import (
+    RESERVED_KEYS,
+    build_slug_registry,
+    decode_state,
+    encode_state,
+    model_slug,
+)
+
+MEASLES_LABEL = "Measles Outbreak Cost Estimation"
+TB_LABEL = "TB Isolation Cost Estimation"
 
 
-def test_roundtrip_simple() -> None:
-    model = "Test Model"
-    values = {"rate": 0.5, "count": 100, "label": "hello"}
-    encoded = encode_params(model, values)
-    result = decode_params(encoded)
-    assert result is not None
-    assert result[0] == model
-    assert result[1] == values
-    assert result[2] is None
+@pytest.fixture(scope="module")
+def registry() -> dict[str, BaseSimulationModel]:
+    return {m.human_name(): m for m in get_all_models()}
 
 
-def test_roundtrip_empty_params() -> None:
-    encoded = encode_params("M", {})
-    result = decode_params(encoded)
-    assert result == ("M", {}, None)
+@pytest.fixture
+def measles(registry: dict[str, BaseSimulationModel]) -> BaseSimulationModel:
+    return registry[MEASLES_LABEL]
 
 
-def test_roundtrip_scenarios() -> None:
+@pytest.fixture
+def tb(registry: dict[str, BaseSimulationModel]) -> BaseSimulationModel:
+    return registry[TB_LABEL]
+
+
+def defaults_of(model: BaseSimulationModel) -> dict[str, Any]:
+    """The model's equation-parameter defaults, as the sidebar would report them."""
+    return {pid: spec.default for pid, spec in (model.parameter_specs or {}).items()}
+
+
+def roundtrip(model: BaseSimulationModel, query: dict[str, str]) -> dict[str, str]:
+    """Decode *query* then re-encode it, as the app does on every rerun."""
+    values, scenarios, _ = decode_state(model, query)
+    return encode_state(model, {**defaults_of(model), **values}, scenarios)
+
+
+# --------------------------------------------------------------------------
+# Slugs
+# --------------------------------------------------------------------------
+
+
+def test_slugs_come_from_the_yaml_file_stem(
+    measles: BaseSimulationModel, tb: BaseSimulationModel
+) -> None:
+    assert model_slug(measles) == "measles"
+    assert model_slug(tb) == "tb_isolation"
+
+
+def test_slug_registry_maps_back_to_labels(
+    registry: dict[str, BaseSimulationModel],
+) -> None:
+    assert build_slug_registry(registry) == {
+        "measles": MEASLES_LABEL,
+        "tb_isolation": TB_LABEL,
+    }
+
+
+def test_shipped_models_avoid_reserved_parameter_names(
+    registry: dict[str, BaseSimulationModel],
+) -> None:
+    for model in registry.values():
+        names = set(model.parameter_specs or {}) | set(
+            model.scenario_parameter_specs or {}
+        )
+        assert not (names & RESERVED_KEYS), model.human_name()
+
+
+# --------------------------------------------------------------------------
+# Encoding
+# --------------------------------------------------------------------------
+
+
+def test_default_state_encodes_to_the_model_alone(measles: BaseSimulationModel) -> None:
+    query = encode_state(measles, defaults_of(measles), measles.default_scenarios)
+
+    assert query == {"model": "measles"}
+
+
+def test_only_changed_parameters_appear(measles: BaseSimulationModel) -> None:
+    params = {**defaults_of(measles), "vaccination_rate": 0.9}
+
+    query = encode_state(measles, params, measles.default_scenarios)
+
+    assert query == {"model": "measles", "vaccination_rate": "0.9"}
+
+
+def test_whole_floats_lose_their_trailing_zero(measles: BaseSimulationModel) -> None:
+    params = {**defaults_of(measles), "contacts_per_case": 200.0}
+
+    query = encode_state(measles, params, measles.default_scenarios)
+
+    assert query["contacts_per_case"] == "200"
+
+
+def test_scenario_overrides_are_keyed_by_scenario_id(
+    measles: BaseSimulationModel,
+) -> None:
     scenarios = [
-        Scenario(
-            id="test_1",
-            label="Test 1",
-            vars=ScenarioVars(n_cases=1000),
-        ),
-        Scenario(
-            id="baseline",
-            label="100 Cases",
-            vars=ScenarioVars(n_cases=100),
-        ),
-    ]
-
-    result = decode_params(encode_params("Measles", {"rate": 0.5}, scenarios))
-
-    assert result == ("Measles", {"rate": 0.5}, scenarios)
-
-
-def test_decode_legacy_parameter_only_payload() -> None:
-    raw = json.dumps({"model": "Legacy", "values": {"count": 22}})
-    encoded = base64.urlsafe_b64encode(raw.encode()).decode().rstrip("=")
-
-    assert decode_params(encoded) == ("Legacy", {"count": 22}, None)
-
-
-def test_decode_invalid_returns_none() -> None:
-    assert decode_params("not-valid-base64!!!") is None
-    assert decode_params("") is None
-
-
-def test_decode_wrong_shape_returns_none() -> None:
-    # Missing 'model' key
-    raw = json.dumps({"values": {}})
-    encoded = base64.urlsafe_b64encode(raw.encode()).decode().rstrip("=")
-    assert decode_params(encoded) is None
-
-
-def test_decode_invalid_scenario_returns_none() -> None:
-    raw = json.dumps(
-        {
-            "model": "M",
-            "values": {},
-            "scenarios": [{"id": "missing-label-and-vars"}],
-        }
-    )
-    encoded = base64.urlsafe_b64encode(raw.encode()).decode().rstrip("=")
-
-    assert decode_params(encoded) is None
-
-
-def test_app_restores_and_rewrites_complete_simulator_state() -> None:
-    model = "Measles Outbreak Cost Estimation"
-    scenarios = [
-        Scenario(id="22_cases", label="Test 1", vars=ScenarioVars(n_cases=1000)),
+        Scenario(id="22_cases", label="Small outbreak", vars=ScenarioVars(n_cases=30)),
         Scenario(id="100_cases", label="100 Cases", vars=ScenarioVars(n_cases=100)),
         Scenario(id="803_cases", label="803 Cases", vars=ScenarioVars(n_cases=803)),
     ]
+
+    query = encode_state(measles, defaults_of(measles), scenarios)
+
+    assert query == {
+        "model": "measles",
+        "scen.22_cases.label": "Small outbreak",
+        "scen.22_cases.n_cases": "30",
+    }
+
+
+def test_changed_scenario_set_emits_an_order_key(measles: BaseSimulationModel) -> None:
+    scenarios = [
+        Scenario(id="22_cases", label="22 Cases", vars=ScenarioVars(n_cases=22)),
+        Scenario(id="custom_3", label="Scenario 2", vars=ScenarioVars(n_cases=7)),
+    ]
+
+    query = encode_state(measles, defaults_of(measles), scenarios)
+
+    assert query == {
+        "model": "measles",
+        "scenarios": "22_cases,custom_3",
+        "scen.custom_3.n_cases": "7",
+    }
+
+
+def test_slug_override_names_a_different_model(measles: BaseSimulationModel) -> None:
+    query = encode_state(measles, defaults_of(measles), None, slug="elsewhere")
+
+    assert query["model"] == "elsewhere"
+
+
+# --------------------------------------------------------------------------
+# Decoding
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("param_id", "text", "expected"),
+    [
+        ("contacts_per_case", "200", 200.0),
+        ("contacts_per_case", "141.5", 141.5),
+        ("quarantine_days", "10", 10),
+        ("vaccination_rate", "0.9", 0.9),
+    ],
+)
+def test_values_decode_to_native_types(
+    measles: BaseSimulationModel, param_id: str, text: str, expected: Any
+) -> None:
+    values, _, warnings = decode_state(measles, {"model": "measles", param_id: text})
+
+    assert values == {param_id: expected}
+    assert type(values[param_id]) is type(expected)
+    assert warnings == []
+
+
+def test_enum_value_decodes(tb: BaseSimulationModel) -> None:
+    values, _, warnings = decode_state(
+        tb, {"model": "tb_isolation", "isolation_type": "MOTEL_ISO"}
+    )
+
+    assert values == {"isolation_type": "MOTEL_ISO"}
+    assert warnings == []
+
+
+def test_unknown_keys_are_ignored(measles: BaseSimulationModel) -> None:
+    values, scenarios, warnings = decode_state(
+        measles, {"model": "measles", "embed": "true", "not_a_param": "9"}
+    )
+
+    assert values == {}
+    assert scenarios is None
+    assert warnings == []
+
+
+def test_untouched_scenarios_decode_to_none(measles: BaseSimulationModel) -> None:
+    _, scenarios, _ = decode_state(measles, {"model": "measles"})
+
+    assert scenarios is None
+
+
+def test_scenario_label_and_var_decode_by_id(measles: BaseSimulationModel) -> None:
+    _, scenarios, warnings = decode_state(
+        measles,
+        {
+            "model": "measles",
+            "scen.22_cases.label": "Small outbreak",
+            "scen.22_cases.n_cases": "30",
+        },
+    )
+
+    assert scenarios is not None
+    assert [(s.id, s.label, s.vars.model_dump()) for s in scenarios] == [
+        ("22_cases", "Small outbreak", {"n_cases": 30}),
+        ("100_cases", "100 Cases", {"n_cases": 100}),
+        ("803_cases", "803 Cases", {"n_cases": 803}),
+    ]
+    assert warnings == []
+
+
+def test_scenario_order_key_selects_membership(measles: BaseSimulationModel) -> None:
+    _, scenarios, warnings = decode_state(
+        measles,
+        {"model": "measles", "scenarios": "803_cases,22_cases"},
+    )
+
+    assert scenarios is not None
+    assert [s.id for s in scenarios] == ["803_cases", "22_cases"]
+    assert warnings == []
+
+
+# --------------------------------------------------------------------------
+# Bad input
+# --------------------------------------------------------------------------
+
+
+def test_value_above_maximum_is_clamped_with_a_warning(
+    measles: BaseSimulationModel,
+) -> None:
+    values, _, warnings = decode_state(
+        measles, {"model": "measles", "vaccination_rate": "5"}
+    )
+
+    assert values == {"vaccination_rate": 1.0}
+    assert len(warnings) == 1
+    assert "above the maximum" in warnings[0]
+
+
+def test_value_below_minimum_is_clamped_with_a_warning(
+    measles: BaseSimulationModel,
+) -> None:
+    values, _, warnings = decode_state(
+        measles, {"model": "measles", "hourly_wage_worker": "-3"}
+    )
+
+    assert values == {"hourly_wage_worker": 0.0}
+    assert len(warnings) == 1
+    assert "below the minimum" in warnings[0]
+
+
+def test_unparseable_number_is_dropped_with_a_warning(
+    measles: BaseSimulationModel,
+) -> None:
+    values, _, warnings = decode_state(
+        measles, {"model": "measles", "vaccination_rate": "abc"}
+    )
+
+    assert values == {}
+    assert warnings == ["Ignored `vaccination_rate=abc`: expected a number."]
+
+
+def test_unknown_enum_constant_is_dropped_with_a_warning(
+    tb: BaseSimulationModel,
+) -> None:
+    values, _, warnings = decode_state(
+        tb, {"model": "tb_isolation", "isolation_type": "motel"}
+    )
+
+    assert values == {}
+    assert len(warnings) == 1
+    assert "HOSP_ISO, MOTEL_ISO, HOME_ISO" in warnings[0]
+
+
+def test_scenario_variable_at_top_level_is_explained(
+    measles: BaseSimulationModel,
+) -> None:
+    values, scenarios, warnings = decode_state(
+        measles, {"model": "measles", "n_cases": "50"}
+    )
+
+    assert values == {}
+    assert scenarios is None
+    assert len(warnings) == 1
+    assert "scen.<scenario>.n_cases" in warnings[0]
+
+
+def test_override_for_an_absent_scenario_is_reported(
+    measles: BaseSimulationModel,
+) -> None:
+    _, _, warnings = decode_state(
+        measles, {"model": "measles", "scen.nope.n_cases": "5"}
+    )
+
+    assert warnings == ["Ignored `scen.nope.n_cases`: no scenario with id `nope`."]
+
+
+def test_too_many_scenarios_are_truncated(measles: BaseSimulationModel) -> None:
+    ids = ",".join(f"s{i}" for i in range(12))
+
+    _, scenarios, warnings = decode_state(
+        measles, {"model": "measles", "scenarios": ids}
+    )
+
+    assert scenarios is not None
+    assert len(scenarios) == 10
+    assert any("only the first 10" in w for w in warnings)
+
+
+# --------------------------------------------------------------------------
+# Idempotency -- the URL is rewritten on every rerun, so it must be stable.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        {"model": "measles"},
+        {"model": "measles", "vaccination_rate": "0.9", "contacts_per_case": "200"},
+        {
+            "model": "measles",
+            "scen.22_cases.label": "Small outbreak",
+            "scen.22_cases.n_cases": "30",
+        },
+        {
+            "model": "measles",
+            "scenarios": "22_cases,custom_3",
+            "scen.custom_3.n_cases": "7",
+        },
+    ],
+)
+def test_roundtrip_is_stable(
+    measles: BaseSimulationModel, query: dict[str, str]
+) -> None:
+    assert roundtrip(measles, query) == query
+
+
+def test_roundtrip_is_stable_for_the_enum_model(tb: BaseSimulationModel) -> None:
+    query = {
+        "model": "tb_isolation",
+        "isolation_type": "MOTEL_ISO",
+        "discount_rate": "0.05",
+        "scen.5_day.label": "Short isolation",
+    }
+
+    assert roundtrip(tb, query) == query
+
+
+def test_clamped_value_settles_after_one_roundtrip(
+    measles: BaseSimulationModel,
+) -> None:
+    once = roundtrip(measles, {"model": "measles", "vaccination_rate": "5"})
+
+    assert once == {"model": "measles", "vaccination_rate": "1"}
+    assert roundtrip(measles, once) == once
+
+
+# --------------------------------------------------------------------------
+# End-to-end through the app
+# --------------------------------------------------------------------------
+
+
+def test_app_restores_and_rewrites_complete_simulator_state() -> None:
     app = AppTest.from_file("app.py")
-    app.query_params["params"] = encode_params(
-        model,
-        {"contacts_per_case": 200.0},
-        scenarios,
+    app.query_params.update(
+        {
+            "model": "measles",
+            "contacts_per_case": "200",
+            "scen.22_cases.label": "Test 1",
+            "scen.22_cases.n_cases": "1000",
+        }
     )
 
     app.run(timeout=30)
 
     assert not app.exception
-    assert app.session_state["model_selector"] == model
-    assert app.session_state[f"{model}:contacts_per_case"] == 200.0
-    assert app.session_state[f"{model}:scen_0:label"] == "Test 1"
-    assert app.session_state[f"{model}:scen_0:n_cases"] == 1000
+    assert app.session_state["model_selector"] == MEASLES_LABEL
+    assert app.session_state[f"{MEASLES_LABEL}:contacts_per_case"] == 200.0
+    assert app.session_state[f"{MEASLES_LABEL}:scen_0:label"] == "Test 1"
+    assert app.session_state[f"{MEASLES_LABEL}:scen_0:n_cases"] == 1000
 
-    rewritten = decode_params(app.query_params["params"][0])
-    assert rewritten is not None
-    assert rewritten[2] == scenarios
+    # AppTest exposes query values as single-item lists.
+    assert app.query_params["model"][0] == "measles"
+    assert app.query_params["contacts_per_case"][0] == "200"
+    assert app.query_params["scen.22_cases.label"][0] == "Test 1"
+    assert app.query_params["scen.22_cases.n_cases"][0] == "1000"
+
+
+def test_app_warns_when_the_link_names_an_unknown_model() -> None:
+    app = AppTest.from_file("app.py")
+    app.query_params["model"] = "no_such_model"
+
+    app.run(timeout=30)
+
+    assert not app.exception
+    assert app.session_state["model_selector"] is None
+    assert any("no_such_model" in w.value for w in app.warning)

--- a/tests/epicc/test_url_params.py
+++ b/tests/epicc/test_url_params.py
@@ -17,6 +17,7 @@ from epicc.model.schema import (
     TableBlock,
     TableRow,
 )
+from epicc.ui.parameters import native_value
 from epicc.ui.url_params import (
     build_slug_registry,
     decode_state,
@@ -69,6 +70,49 @@ def text_model() -> BaseSimulationModel:
     )
 
 
+def single_parameter_model(
+    param_id: str,
+    *,
+    param_type: str = "integer",
+    default: Any = 1,
+    source_path: str = "single.yaml",
+) -> BaseSimulationModel:
+    """Build a minimal custom model for URL grammar edge cases."""
+    return create_model_instance(
+        Model(
+            title=f"Single {param_id}",
+            description="Exercises one custom parameter id",
+            parameters={
+                param_id: Parameter(type=param_type, label="Value", default=default)
+            },
+            equations={"eq_total": Equation(label="Total", compute="1")},
+            scenarios=[Scenario(id="only", label="Only", vars=ScenarioVars())],
+            report=[
+                TableBlock(
+                    type="table", rows=[TableRow(label="Total", value="eq_total")]
+                )
+            ],
+            groups=[param_id],
+        ),
+        source_path=source_path,
+    )
+
+
+def custom_measles_model(
+    title: str,
+    source_path: str,
+    *,
+    vaccination_default: float | None = None,
+) -> BaseSimulationModel:
+    """Return a Measles-derived custom model with a distinct registry label."""
+    base = next(m for m in get_all_models() if m.human_name() == MEASLES_LABEL)
+    definition = base.get_model_definition().model_copy(deep=True)
+    definition.title = title
+    if vaccination_default is not None:
+        definition.parameters["vaccination_rate"].default = vaccination_default
+    return create_model_instance(definition, source_path=source_path)
+
+
 def defaults_of(model: BaseSimulationModel) -> dict[str, Any]:
     """The model's equation-parameter defaults, as the sidebar would report them."""
     return {pid: spec.default for pid, spec in (model.parameter_specs or {}).items()}
@@ -113,14 +157,18 @@ def test_slug_registry_keeps_collisions(
     ]
 
 
-def test_shipped_models_avoid_reserved_parameter_names(
-    registry: dict[str, BaseSimulationModel],
-) -> None:
-    for model in registry.values():
-        names = set(model.parameter_specs or {}) | set(
-            model.scenario_parameter_specs or {}
-        )
-        assert not [name for name in names if is_reserved(name)], model.human_name()
+@pytest.mark.parametrize(
+    "param_id", ["model", "scenarios", "embed", "Embed", "EMBED_OPTIONS"]
+)
+def test_parameter_ids_that_match_reserved_keys_round_trip(param_id: str) -> None:
+    model = single_parameter_model(param_id)
+
+    query = encode_state(model, {param_id: 7})
+    values, _, warnings = decode_state(model, query)
+
+    assert query == {"model": "single", f"param.{param_id}": "7"}
+    assert values == {param_id: 7}
+    assert warnings == []
 
 
 @pytest.mark.parametrize(
@@ -148,7 +196,7 @@ def test_only_changed_parameters_appear(measles: BaseSimulationModel) -> None:
 
     query = encode_state(measles, params, measles.default_scenarios)
 
-    assert query == {"model": "measles", "vaccination_rate": "0.9"}
+    assert query == {"model": "measles", "param.vaccination_rate": "0.9"}
 
 
 def test_whole_floats_lose_their_trailing_zero(measles: BaseSimulationModel) -> None:
@@ -156,7 +204,7 @@ def test_whole_floats_lose_their_trailing_zero(measles: BaseSimulationModel) -> 
 
     query = encode_state(measles, params, measles.default_scenarios)
 
-    assert query["contacts_per_case"] == "200"
+    assert query["param.contacts_per_case"] == "200"
 
 
 def test_scenario_overrides_are_keyed_by_scenario_id(
@@ -210,6 +258,33 @@ def test_scenario_ids_with_commas_stay_unambiguous(
     assert [s.id for s in decoded] == ["alpha,beta", "gamma"]
 
 
+@pytest.mark.parametrize(("scenario_id", "encoded_id"), [("", "!"), ("!", "%21")])
+def test_empty_scenario_id_token_cannot_collide_with_a_literal_id(
+    measles: BaseSimulationModel, scenario_id: str, encoded_id: str
+) -> None:
+    definition = measles.get_model_definition().model_copy(deep=True)
+    definition.title = f"Scenario id {scenario_id!r}"
+    definition.scenarios = [
+        Scenario(id=scenario_id, label="Original", vars=ScenarioVars(n_cases=22))
+    ]
+    model = create_model_instance(definition, source_path="scenario-id.yaml")
+    scenarios = [
+        Scenario(id=scenario_id, label="Renamed", vars=ScenarioVars(n_cases=30)),
+        Scenario(id="custom_1", label="Scenario 2", vars=ScenarioVars(n_cases=7)),
+    ]
+
+    query = encode_state(model, defaults_of(model), scenarios)
+    assert query["scenarios"] == f"{encoded_id},custom_1"
+
+    _, decoded, warnings = decode_state(model, query)
+    assert decoded is not None
+    assert [(s.id, s.label, s.vars.n_cases) for s in decoded] == [
+        (scenario_id, "Renamed", 30),
+        ("custom_1", "Scenario 2", 7),
+    ]
+    assert warnings == []
+
+
 # --------------------------------------------------------------------------
 # Decoding
 # --------------------------------------------------------------------------
@@ -227,7 +302,9 @@ def test_scenario_ids_with_commas_stay_unambiguous(
 def test_values_decode_to_native_types(
     measles: BaseSimulationModel, param_id: str, text: str, expected: Any
 ) -> None:
-    values, _, warnings = decode_state(measles, {"model": "measles", param_id: text})
+    values, _, warnings = decode_state(
+        measles, {"model": "measles", f"param.{param_id}": text}
+    )
 
     assert values == {param_id: expected}
     assert type(values[param_id]) is type(expected)
@@ -236,7 +313,7 @@ def test_values_decode_to_native_types(
 
 def test_enum_value_decodes(tb: BaseSimulationModel) -> None:
     values, _, warnings = decode_state(
-        tb, {"model": "tb_isolation", "isolation_type": "MOTEL_ISO"}
+        tb, {"model": "tb_isolation", "param.isolation_type": "MOTEL_ISO"}
     )
 
     assert values == {"isolation_type": "MOTEL_ISO"}
@@ -298,7 +375,7 @@ def test_value_above_maximum_is_clamped_with_a_warning(
     measles: BaseSimulationModel,
 ) -> None:
     values, _, warnings = decode_state(
-        measles, {"model": "measles", "vaccination_rate": "5"}
+        measles, {"model": "measles", "param.vaccination_rate": "5"}
     )
 
     assert values == {"vaccination_rate": 1.0}
@@ -310,7 +387,7 @@ def test_value_below_minimum_is_clamped_with_a_warning(
     measles: BaseSimulationModel,
 ) -> None:
     values, _, warnings = decode_state(
-        measles, {"model": "measles", "hourly_wage_worker": "-3"}
+        measles, {"model": "measles", "param.hourly_wage_worker": "-3"}
     )
 
     assert values == {"hourly_wage_worker": 0.0}
@@ -322,40 +399,88 @@ def test_fractional_value_for_an_integer_is_rejected_not_truncated(
     measles: BaseSimulationModel,
 ) -> None:
     values, _, warnings = decode_state(
-        measles, {"model": "measles", "quarantine_days": "10.5"}
+        measles, {"model": "measles", "param.quarantine_days": "10.5"}
     )
 
     assert values == {}
-    assert warnings == ["Ignored `quarantine_days=10.5`: expected a whole number."]
+    assert warnings == [
+        "Ignored `param.quarantine_days=10.5`: expected a whole number."
+    ]
 
 
 def test_integral_float_is_accepted_for_an_integer(
     measles: BaseSimulationModel,
 ) -> None:
     values, _, warnings = decode_state(
-        measles, {"model": "measles", "quarantine_days": "10.0"}
+        measles, {"model": "measles", "param.quarantine_days": "10.0"}
     )
 
     assert values == {"quarantine_days": 10}
     assert warnings == []
 
 
+@pytest.mark.parametrize("text", ["10.0000000000000001", "1e-1000"])
+def test_nearly_integral_values_are_rejected_exactly(
+    measles: BaseSimulationModel, text: str
+) -> None:
+    values, _, warnings = decode_state(
+        measles, {"model": "measles", "param.quarantine_days": text}
+    )
+
+    assert values == {}
+    assert len(warnings) == 1
+    assert "expected a whole number" in warnings[0]
+
+
+def test_integer_scientific_notation_is_accepted_exactly(
+    measles: BaseSimulationModel,
+) -> None:
+    values, _, warnings = decode_state(
+        measles, {"model": "measles", "param.quarantine_days": "1e1"}
+    )
+
+    assert values == {"quarantine_days": 10}
+    assert warnings == []
+
+
+def test_integer_outside_streamlits_safe_range_is_rejected() -> None:
+    model = single_parameter_model("n")
+
+    values, _, warnings = decode_state(
+        model, {"model": "single", "param.n": "9007199254740993"}
+    )
+
+    assert values == {}
+    assert len(warnings) == 1
+    assert "whole numbers must be between" in warnings[0]
+
+
+def test_integer_encoding_does_not_round_through_float() -> None:
+    model = single_parameter_model("n")
+
+    query = encode_state(model, {"n": 9007199254740993})
+
+    assert query["param.n"] == "9007199254740993"
+
+
 def test_unparseable_number_is_dropped_with_a_warning(
     measles: BaseSimulationModel,
 ) -> None:
     values, _, warnings = decode_state(
-        measles, {"model": "measles", "vaccination_rate": "abc"}
+        measles, {"model": "measles", "param.vaccination_rate": "abc"}
     )
 
     assert values == {}
-    assert warnings == ["Ignored `vaccination_rate=abc`: expected a number."]
+    assert warnings == [
+        "Ignored `param.vaccination_rate=abc`: expected a number."
+    ]
 
 
 def test_unknown_enum_constant_is_dropped_with_a_warning(
     tb: BaseSimulationModel,
 ) -> None:
     values, _, warnings = decode_state(
-        tb, {"model": "tb_isolation", "isolation_type": "motel"}
+        tb, {"model": "tb_isolation", "param.isolation_type": "motel"}
     )
 
     assert values == {}
@@ -367,13 +492,63 @@ def test_scenario_variable_at_top_level_is_explained(
     measles: BaseSimulationModel,
 ) -> None:
     values, scenarios, warnings = decode_state(
-        measles, {"model": "measles", "n_cases": "50"}
+        measles, {"model": "measles", "param.n_cases": "50"}
     )
 
     assert values == {}
     assert scenarios is None
     assert len(warnings) == 1
     assert "scen.<scenario>.n_cases" in warnings[0]
+
+
+@pytest.mark.parametrize("param_id", ["vaccination_rate", "n_cases"])
+def test_parameter_without_the_namespace_is_explained(
+    measles: BaseSimulationModel, param_id: str
+) -> None:
+    # A bare id looks right but is just an unknown key, so it would otherwise be
+    # ignored in silence and quietly leave the default in place.
+    values, scenarios, warnings = decode_state(
+        measles, {"model": "measles", param_id: "0.5"}
+    )
+
+    assert values == {}
+    assert scenarios is None
+    assert warnings == [
+        f"Ignored `{param_id}=0.5`: parameters need the `param.` prefix, "
+        f"as `param.{param_id}`."
+    ]
+
+
+def test_reserved_key_names_do_not_trigger_the_namespace_hint() -> None:
+    # `model` is a real query key here, not a parameter someone under-qualified.
+    model = single_parameter_model("model")
+
+    _, _, warnings = decode_state(model, {"model": "single", "param.model": "7"})
+
+    assert warnings == []
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (10, 10),
+        (10.5, 10),
+        ("10", 10),
+        ("10.0", 10),
+        ("1e1", 10),
+        # Exact beyond 2**53, where a float round trip would lose the last digit.
+        (9007199254740993, 9007199254740993),
+        ("9007199254740993", 9007199254740993),
+    ],
+)
+def test_integer_coercion_is_exact_and_still_accepts_text(
+    value: Any, expected: int
+) -> None:
+    # native_value backs the widgets, the dirty markers, and the URL diff, so it
+    # has to agree with the exact parsing decode does.
+    spec = Parameter(type="integer", label="N", default=1)
+
+    assert native_value(value, spec) == expected
 
 
 def test_override_for_an_absent_scenario_is_reported(
@@ -424,7 +599,7 @@ def test_string_values_keep_their_surrounding_whitespace(
     # Stripping here would make encoding and decoding non-inverse: the value
     # goes out with its spaces and would silently come back without them.
     query = encode_state(text_model, {"region": "  north  ", "n_items": 5})
-    assert query["region"] == "  north  "
+    assert query["param.region"] == "  north  "
 
     values, _, warnings = decode_state(text_model, query)
     assert values == {"region": "  north  "}
@@ -456,13 +631,13 @@ def test_warnings_cannot_break_out_of_their_code_span(
     injection = "`![pwned](https://example.invalid/x.png)"
 
     _, _, warnings = decode_state(
-        measles, {"model": "measles", "vaccination_rate": injection}
+        measles, {"model": "measles", "param.vaccination_rate": injection}
     )
 
     assert len(warnings) == 1
     before, quoted, after = warnings[0].split("`")
     assert before == "Ignored "
-    assert quoted == "vaccination_rate=![pwned](https://example.invalid/x.png)"
+    assert quoted == "param.vaccination_rate=![pwned](https://example.invalid/x.png)"
     assert after == ": expected a number."
 
 
@@ -470,7 +645,8 @@ def test_warnings_flatten_newlines_and_truncate_long_values(
     measles: BaseSimulationModel,
 ) -> None:
     _, _, warnings = decode_state(
-        measles, {"model": "measles", "vaccination_rate": "a\n\nb" + "x" * 500}
+        measles,
+        {"model": "measles", "param.vaccination_rate": "a\n\nb" + "x" * 500},
     )
 
     assert len(warnings) == 1
@@ -488,7 +664,11 @@ def test_warnings_flatten_newlines_and_truncate_long_values(
     "query",
     [
         {"model": "measles"},
-        {"model": "measles", "vaccination_rate": "0.9", "contacts_per_case": "200"},
+        {
+            "model": "measles",
+            "param.vaccination_rate": "0.9",
+            "param.contacts_per_case": "200",
+        },
         {
             "model": "measles",
             "scen.22_cases.label": "Small outbreak",
@@ -510,8 +690,8 @@ def test_roundtrip_is_stable(
 def test_roundtrip_is_stable_for_the_enum_model(tb: BaseSimulationModel) -> None:
     query = {
         "model": "tb_isolation",
-        "isolation_type": "MOTEL_ISO",
-        "discount_rate": "0.05",
+        "param.isolation_type": "MOTEL_ISO",
+        "param.discount_rate": "0.05",
         "scen.5_day.label": "Short isolation",
     }
 
@@ -521,9 +701,11 @@ def test_roundtrip_is_stable_for_the_enum_model(tb: BaseSimulationModel) -> None
 def test_clamped_value_settles_after_one_roundtrip(
     measles: BaseSimulationModel,
 ) -> None:
-    once = roundtrip(measles, {"model": "measles", "vaccination_rate": "5"})
+    once = roundtrip(
+        measles, {"model": "measles", "param.vaccination_rate": "5"}
+    )
 
-    assert once == {"model": "measles", "vaccination_rate": "1"}
+    assert once == {"model": "measles", "param.vaccination_rate": "1"}
     assert roundtrip(measles, once) == once
 
 
@@ -532,12 +714,29 @@ def test_clamped_value_settles_after_one_roundtrip(
 # --------------------------------------------------------------------------
 
 
+def test_app_round_trips_a_host_reserved_parameter_id() -> None:
+    model = single_parameter_model("embed")
+    label = model.human_name()
+    app = AppTest.from_file("app.py")
+    app.session_state["custom_models"] = {label: model}
+    app.query_params.update({"model": "single", "param.embed": "7"})
+
+    app.run(timeout=30)
+
+    assert not app.exception
+    assert app.session_state[f"{label}:embed"] == 7
+    assert dict(app.query_params) == {
+        "model": ["single"],
+        "param.embed": ["7"],
+    }
+
+
 def test_app_restores_and_rewrites_complete_simulator_state() -> None:
     app = AppTest.from_file("app.py")
     app.query_params.update(
         {
             "model": "measles",
-            "contacts_per_case": "200",
+            "param.contacts_per_case": "200",
             "scen.22_cases.label": "Test 1",
             "scen.22_cases.n_cases": "1000",
         }
@@ -553,7 +752,7 @@ def test_app_restores_and_rewrites_complete_simulator_state() -> None:
 
     # AppTest exposes query values as single-item lists.
     assert app.query_params["model"][0] == "measles"
-    assert app.query_params["contacts_per_case"][0] == "200"
+    assert app.query_params["param.contacts_per_case"][0] == "200"
     assert app.query_params["scen.22_cases.label"][0] == "Test 1"
     assert app.query_params["scen.22_cases.n_cases"][0] == "1000"
 
@@ -573,7 +772,7 @@ def test_app_keeps_an_unresolved_link_pending_until_its_model_loads() -> None:
     # The link names a model the session doesn't have yet. Discarding it here
     # would open the model at its own defaults once it finally showed up.
     app = AppTest.from_file("app.py")
-    app.query_params.update({"model": "later", "contacts_per_case": "200"})
+    app.query_params.update({"model": "later", "param.contacts_per_case": "200"})
 
     app.run(timeout=30)
     assert not app.exception
@@ -593,6 +792,70 @@ def test_app_keeps_an_unresolved_link_pending_until_its_model_loads() -> None:
     assert app.session_state["later:contacts_per_case"] == 200.0
 
 
+def test_app_reports_decode_warnings_after_a_missing_model_loads() -> None:
+    app = AppTest.from_file("app.py")
+    app.query_params.update(
+        {"model": "later", "param.contacts_per_case": "not-a-number"}
+    )
+
+    app.run(timeout=30)
+    assert not app.exception
+    assert any("isn't loaded here" in warning.value for warning in app.warning)
+
+    app.session_state["custom_models"] = {
+        "later": custom_measles_model("Later model", "later.yaml")
+    }
+    app.run(timeout=30)
+
+    assert not app.exception
+    assert app.session_state["later:contacts_per_case"] == 141.5
+    assert any("expected a number" in warning.value for warning in app.warning)
+    assert dict(app.query_params) == {"model": ["later"]}
+
+    app.run(timeout=30)
+    assert not any("expected a number" in warning.value for warning in app.warning)
+
+
+def test_app_applies_pending_values_to_the_selected_ambiguous_model() -> None:
+    custom_label = "Custom Measles"
+    app = AppTest.from_file("app.py")
+    app.session_state["custom_models"] = {
+        custom_label: custom_measles_model(custom_label, "measles.yaml")
+    }
+    app.query_params.update(
+        {"model": "measles", "param.contacts_per_case": "200"}
+    )
+
+    app.run(timeout=30)
+    assert not app.exception
+    assert app.session_state["model_selector"] is None
+    assert any("more than one loaded model" in w.value for w in app.warning)
+
+    app.selectbox[0].select(custom_label).run(timeout=30)
+
+    assert not app.exception
+    assert app.session_state[f"{custom_label}:contacts_per_case"] == 200.0
+    assert dict(app.query_params) == {}
+    assert any("Link sharing is unavailable" in w.value for w in app.warning)
+
+
+def test_app_publishes_no_link_for_a_colliding_custom_slug() -> None:
+    custom_label = "Edited Measles"
+    custom_model = custom_measles_model(
+        custom_label, "measles.yaml", vaccination_default=0.9
+    )
+
+    app = AppTest.from_file("app.py")
+    app.session_state["custom_models"] = {custom_label: custom_model}
+    app.session_state["model_selector"] = custom_label
+
+    app.run(timeout=30)
+
+    assert not app.exception
+    assert dict(app.query_params) == {}
+    assert any("Link sharing is unavailable" in w.value for w in app.warning)
+
+
 def test_app_publishes_no_link_while_previewing_an_edited_model() -> None:
     # A preview's values are diffed against the edited defaults, so any link
     # written here would reopen the saved model showing different numbers.
@@ -601,7 +864,9 @@ def test_app_publishes_no_link_while_previewing_an_edited_model() -> None:
     edited.parameters["vaccination_rate"].default = 0.9
 
     app = AppTest.from_file("app.py")
-    app.query_params.update({"model": "measles", "contacts_per_case": "200"})
+    app.query_params.update(
+        {"model": "measles", "param.contacts_per_case": "200"}
+    )
     app.session_state["epicc_editor_preview_model"] = create_model_instance(edited)
     app.session_state["epicc_editor_preview_label"] = MEASLES_LABEL
     # Match the rerun that "Try in Calculator" produces: the model is already

--- a/tests/epicc/test_url_params.py
+++ b/tests/epicc/test_url_params.py
@@ -6,13 +6,22 @@ import pytest
 from streamlit.testing.v1 import AppTest
 
 from epicc.model.base import BaseSimulationModel
+from epicc.model.factory import create_model_instance
 from epicc.model.models import get_all_models
-from epicc.model.schema import Scenario, ScenarioVars
+from epicc.model.schema import (
+    Equation,
+    Model,
+    Parameter,
+    Scenario,
+    ScenarioVars,
+    TableBlock,
+    TableRow,
+)
 from epicc.ui.url_params import (
-    RESERVED_KEYS,
     build_slug_registry,
     decode_state,
     encode_state,
+    is_reserved,
     model_slug,
 )
 
@@ -33,6 +42,31 @@ def measles(registry: dict[str, BaseSimulationModel]) -> BaseSimulationModel:
 @pytest.fixture
 def tb(registry: dict[str, BaseSimulationModel]) -> BaseSimulationModel:
     return registry[TB_LABEL]
+
+
+@pytest.fixture
+def text_model() -> BaseSimulationModel:
+    """A model with a string parameter -- neither shipped model has one."""
+    return create_model_instance(
+        Model(
+            title="Text Model",
+            description="Exercises string-typed parameters",
+            parameters={
+                "region": Parameter(type="string", label="Region", default="north"),
+                "n_items": Parameter(type="integer", label="Items", default=5, min=1),
+            },
+            equations={"eq_total": Equation(label="Total", compute="n_items * 1")},
+            scenarios=[
+                Scenario(id="only", label="Only", vars=ScenarioVars()),
+            ],
+            report=[
+                TableBlock(
+                    type="table", rows=[TableRow(label="Total", value="eq_total")]
+                )
+            ],
+            groups=["region", "n_items"],
+        )
+    )
 
 
 def defaults_of(model: BaseSimulationModel) -> dict[str, Any]:
@@ -62,9 +96,21 @@ def test_slug_registry_maps_back_to_labels(
     registry: dict[str, BaseSimulationModel],
 ) -> None:
     assert build_slug_registry(registry) == {
-        "measles": MEASLES_LABEL,
-        "tb_isolation": TB_LABEL,
+        "measles": [MEASLES_LABEL],
+        "tb_isolation": [TB_LABEL],
     }
+
+
+def test_slug_registry_keeps_collisions(
+    registry: dict[str, BaseSimulationModel],
+) -> None:
+    # An uploaded measles.yaml lands under a different label but the same slug.
+    shadowed = {**registry, "[Custom] measles": registry[MEASLES_LABEL]}
+
+    assert build_slug_registry(shadowed)["measles"] == [
+        MEASLES_LABEL,
+        "[Custom] measles",
+    ]
 
 
 def test_shipped_models_avoid_reserved_parameter_names(
@@ -74,7 +120,16 @@ def test_shipped_models_avoid_reserved_parameter_names(
         names = set(model.parameter_specs or {}) | set(
             model.scenario_parameter_specs or {}
         )
-        assert not (names & RESERVED_KEYS), model.human_name()
+        assert not [name for name in names if is_reserved(name)], model.human_name()
+
+
+@pytest.mark.parametrize(
+    "name", ["model", "scenarios", "embed", "embed_options", "Embed", "EMBED_OPTIONS"]
+)
+def test_reserved_names_include_streamlits_own_case_insensitively(name: str) -> None:
+    # st.query_params.from_dict raises StreamlitAPIException on embed keys, so
+    # writing one would crash the app rather than produce a bad link.
+    assert is_reserved(name)
 
 
 # --------------------------------------------------------------------------
@@ -137,10 +192,22 @@ def test_changed_scenario_set_emits_an_order_key(measles: BaseSimulationModel) -
     }
 
 
-def test_slug_override_names_a_different_model(measles: BaseSimulationModel) -> None:
-    query = encode_state(measles, defaults_of(measles), None, slug="elsewhere")
+def test_scenario_ids_with_commas_stay_unambiguous(
+    measles: BaseSimulationModel,
+) -> None:
+    # Scenario.id is an unconstrained string, so a comma would otherwise split
+    # one scenario into two on the way back in.
+    scenarios = [
+        Scenario(id="alpha,beta", label="Scenario 1", vars=ScenarioVars(n_cases=22)),
+        Scenario(id="gamma", label="Scenario 2", vars=ScenarioVars(n_cases=40)),
+    ]
 
-    assert query["model"] == "elsewhere"
+    query = encode_state(measles, defaults_of(measles), scenarios)
+    assert query["scenarios"] == "alpha%2Cbeta,gamma"
+
+    _, decoded, _ = decode_state(measles, query)
+    assert decoded is not None
+    assert [s.id for s in decoded] == ["alpha,beta", "gamma"]
 
 
 # --------------------------------------------------------------------------
@@ -251,6 +318,28 @@ def test_value_below_minimum_is_clamped_with_a_warning(
     assert "below the minimum" in warnings[0]
 
 
+def test_fractional_value_for_an_integer_is_rejected_not_truncated(
+    measles: BaseSimulationModel,
+) -> None:
+    values, _, warnings = decode_state(
+        measles, {"model": "measles", "quarantine_days": "10.5"}
+    )
+
+    assert values == {}
+    assert warnings == ["Ignored `quarantine_days=10.5`: expected a whole number."]
+
+
+def test_integral_float_is_accepted_for_an_integer(
+    measles: BaseSimulationModel,
+) -> None:
+    values, _, warnings = decode_state(
+        measles, {"model": "measles", "quarantine_days": "10.0"}
+    )
+
+    assert values == {"quarantine_days": 10}
+    assert warnings == []
+
+
 def test_unparseable_number_is_dropped_with_a_warning(
     measles: BaseSimulationModel,
 ) -> None:
@@ -297,6 +386,26 @@ def test_override_for_an_absent_scenario_is_reported(
     assert warnings == ["Ignored `scen.nope.n_cases`: no scenario with id `nope`."]
 
 
+def test_misspelled_scenario_field_is_reported(measles: BaseSimulationModel) -> None:
+    # The scenario id is real, so this would otherwise be dropped in silence and
+    # quietly run the default 22-case calculation.
+    _, _, warnings = decode_state(
+        measles, {"model": "measles", "scen.22_cases.n_case": "30"}
+    )
+
+    assert warnings == [
+        "Ignored `scen.22_cases.n_case`: scenarios accept `label, n_cases`."
+    ]
+
+
+def test_scenario_key_without_a_field_is_reported(
+    measles: BaseSimulationModel,
+) -> None:
+    _, _, warnings = decode_state(measles, {"model": "measles", "scen.22_cases": "30"})
+
+    assert warnings == ["Ignored `scen.22_cases`: expected `scen.<scenario>.<field>`."]
+
+
 def test_too_many_scenarios_are_truncated(measles: BaseSimulationModel) -> None:
     ids = ",".join(f"s{i}" for i in range(12))
 
@@ -307,6 +416,67 @@ def test_too_many_scenarios_are_truncated(measles: BaseSimulationModel) -> None:
     assert scenarios is not None
     assert len(scenarios) == 10
     assert any("only the first 10" in w for w in warnings)
+
+
+def test_string_values_keep_their_surrounding_whitespace(
+    text_model: BaseSimulationModel,
+) -> None:
+    # Stripping here would make encoding and decoding non-inverse: the value
+    # goes out with its spaces and would silently come back without them.
+    query = encode_state(text_model, {"region": "  north  ", "n_items": 5})
+    assert query["region"] == "  north  "
+
+    values, _, warnings = decode_state(text_model, query)
+    assert values == {"region": "  north  "}
+    assert warnings == []
+
+
+def test_scenario_labels_keep_their_surrounding_whitespace(
+    measles: BaseSimulationModel,
+) -> None:
+    _, scenarios, _ = decode_state(
+        measles, {"model": "measles", "scen.22_cases.label": "  Small  "}
+    )
+
+    assert scenarios is not None
+    assert scenarios[0].label == "  Small  "
+
+
+# --------------------------------------------------------------------------
+# Warning rendering -- st.warning renders Markdown, and these strings quote
+# text taken straight from the URL.
+# --------------------------------------------------------------------------
+
+
+def test_warnings_cannot_break_out_of_their_code_span(
+    measles: BaseSimulationModel,
+) -> None:
+    # A backtick would close the span and let the rest render as Markdown --
+    # here, a remote image pulled into trusted app chrome.
+    injection = "`![pwned](https://example.invalid/x.png)"
+
+    _, _, warnings = decode_state(
+        measles, {"model": "measles", "vaccination_rate": injection}
+    )
+
+    assert len(warnings) == 1
+    before, quoted, after = warnings[0].split("`")
+    assert before == "Ignored "
+    assert quoted == "vaccination_rate=![pwned](https://example.invalid/x.png)"
+    assert after == ": expected a number."
+
+
+def test_warnings_flatten_newlines_and_truncate_long_values(
+    measles: BaseSimulationModel,
+) -> None:
+    _, _, warnings = decode_state(
+        measles, {"model": "measles", "vaccination_rate": "a\n\nb" + "x" * 500}
+    )
+
+    assert len(warnings) == 1
+    assert "\n" not in warnings[0]
+    assert len(warnings[0]) < 200
+    assert "..." in warnings[0]
 
 
 # --------------------------------------------------------------------------
@@ -397,3 +567,63 @@ def test_app_warns_when_the_link_names_an_unknown_model() -> None:
     assert not app.exception
     assert app.session_state["model_selector"] is None
     assert any("no_such_model" in w.value for w in app.warning)
+
+
+def test_app_keeps_an_unresolved_link_pending_until_its_model_loads() -> None:
+    # The link names a model the session doesn't have yet. Discarding it here
+    # would open the model at its own defaults once it finally showed up.
+    app = AppTest.from_file("app.py")
+    app.query_params.update({"model": "later", "contacts_per_case": "200"})
+
+    app.run(timeout=30)
+    assert not app.exception
+    assert app.session_state["model_selector"] is None
+    assert "_url_params_applied" not in app.session_state
+
+    # The model arrives, exactly as uploading a custom model would deliver it.
+    definition = get_all_models()[0].get_model_definition()
+    app.session_state["custom_models"] = {
+        "later": create_model_instance(definition, source_path="later.yaml")
+    }
+
+    app.run(timeout=30)
+
+    assert not app.exception
+    assert app.session_state["model_selector"] == "later"
+    assert app.session_state["later:contacts_per_case"] == 200.0
+
+
+def test_app_publishes_no_link_while_previewing_an_edited_model() -> None:
+    # A preview's values are diffed against the edited defaults, so any link
+    # written here would reopen the saved model showing different numbers.
+    measles_model = next(m for m in get_all_models() if m.human_name() == MEASLES_LABEL)
+    edited = measles_model.get_model_definition().model_copy(deep=True)
+    edited.parameters["vaccination_rate"].default = 0.9
+
+    app = AppTest.from_file("app.py")
+    app.query_params.update({"model": "measles", "contacts_per_case": "200"})
+    app.session_state["epicc_editor_preview_model"] = create_model_instance(edited)
+    app.session_state["epicc_editor_preview_label"] = MEASLES_LABEL
+    # Match the rerun that "Try in Calculator" produces: the model is already
+    # active, so sync_active_model won't discard the preview.
+    app.session_state["active_model_key"] = MEASLES_LABEL
+    app.session_state["model_selector"] = MEASLES_LABEL
+
+    app.run(timeout=30)
+
+    assert not app.exception
+    assert app.session_state["model_selector"] == MEASLES_LABEL
+    assert dict(app.query_params) == {}
+
+
+def test_app_escapes_query_text_in_warnings() -> None:
+    app = AppTest.from_file("app.py")
+    app.query_params["model"] = "`![pwned](https://example.invalid/x.png)"
+
+    app.run(timeout=30)
+
+    assert not app.exception
+    warned = [w.value for w in app.warning if "pwned" in w.value]
+    assert len(warned) == 1
+    # Balanced delimiters mean the injected Markdown stayed inside the span.
+    assert warned[0].count("`") == 2

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "epicc"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "numpy" },

--- a/uv.lock
+++ b/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "epicc"
-version = "0.2.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## What changed

The URL that carries simulator state is now human-readable. Instead of

```
?params=eyJtb2RlbCI6Ik1lYXNsZXMgT3V0YnJlYWsgQ29zdCBFc3RpbWF0aW9uIiwi...
```

a shared link reads:

```
?model=measles&vaccination_rate=0.9&scen.22_cases.label=Small+outbreak&scen.22_cases.n_cases=30
```

| Key | Meaning |
| --- | --- |
| `model` | Model slug, from the YAML file stem (`measles`, `tb_isolation`) |
| `<param_id>` | Equation parameter, keyed by its id in the model YAML |
| `scen.<id>.<var>` / `scen.<id>.label` | Scenario overrides, keyed by scenario id |
| `scenarios` | Comma-separated ordered scenario ids — emitted only when the scenario set or order differs from the model's defaults |

Only values that differ from the model's defaults appear, so a link shows exactly what the sender changed and nothing else. Opening a model untouched leaves the URL at `?model=measles`, and returning a value to its default removes its key again.

## Why

The base64 payload worked, but it hid everything. A link couldn't be read, hand-edited, constructed by hand, or pasted into a paper or grant appendix as a record of the inputs. The app also ships as a static stlite bundle where the URL is the only cross-session persistence, so it's worth making legible. At the actual scale involved — 9–17 equation parameters and 2–3 scenarios per shipped model — the readable form is usually *shorter* than the base64 it replaces.

## Breaking change

**Links produced by v0.1.0 no longer load.** Base64 payloads are not decoded at all; a `?params=...` link now falls through to the model picker. Version bumped to `0.2.0` as the pre-1.0 signal for this. (AGENTS.md's literal rule points at MAJOR, which at `0.1.0` would mean `1.0.0` — happy to re-cut it that way if you'd rather.)

## Notes for review

- **`encode_state` / `decode_state` are spec-driven.** They take the `BaseSimulationModel`, which is what allows diffing against `Parameter.default` on the way out and coercing on the way in. This is the shape change from the old label-and-dict API.
- **Clamping is load-bearing, not cosmetic.** `_render_spec_widget` passes `min_value`/`max_value` into `st.number_input`, and Streamlit raises if a session-state value sits outside that range. Hand-edited URLs make out-of-range values likely, so decode clamps numerics, rejects unknown enum constants, and drops unparseable values — each with a warning surfaced via `st.warning` instead of the old silent `return None`.
- **Idempotency matters.** `write_url_state` fires on every rerun, immediately after a URL-driven restore, so `encode(decode(q)) == q` has to hold. There are parametrized tests for it, including that a clamped value settles after one round trip.
- **Scenarios are keyed by id, not index.** Session state is positional (`{model}:scen_{idx}:{var}`), but ids (`22_cases`, `14_day`) are what a reader recognises. Decoding starts from `model.default_scenarios` and only consults `scenarios=` when membership or order changed.
- **`model` and `scenarios` are reserved key names.** A parameter with either id is skipped by the encoder and never read by the decoder. There's a test asserting neither shipped model collides.
- **Preview models get the selected model's slug.** An unsaved editor preview has no source file, so its link names the saved model rather than emitting a slug that resolves to nothing.
- `native_value` and `MAX_SCENARIOS` in `ui/parameters.py` were promoted from private for reuse. `clear_url_params` had no callers and was dropped.
- The restore guard now sets `_url_params_applied` on every path, so an unrecognised model no longer re-parses the query string on each rerun.

## Verification

`make check` is green — 149 tests, ruff and mypy clean. `tests/epicc/test_url_params.py` is 33 tests against the real shipped models, covering round trips per parameter type, clamping, bad input, reserved names, and idempotency.

Also driven against the running app:

- The example link above restored `vaccination_rate=0.90` and scenario 1 as "Small outbreak"/30, with the URL unchanged afterwards.
- Setting `vaccination_rate` back to `0.8` dropped the key from the URL.
- A deliberately broken link (`vaccination_rate=5&junk=1&n_cases=50&scen.nope.n_cases=9&contacts_per_case=abc`) loaded cleanly with four precise warnings and settled to `?model=measles&vaccination_rate=1`; the unrecognised `junk=1` was ignored silently, as intended.
- A typo'd slug (`tb_isolatino`) warned and fell through to the welcome page.
- `tb_isolation` restored its enum (`MOTEL_ISO` → "Motel, with nurse") and its 2-scenario editor.

One thing worth knowing: the per-rerun write still adds a browser history entry on each query change. That's `_send_query_param_msg` sending one `page_info_changed` message, identical for `from_dict` and the old `__setitem__` — pre-existing behavior, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
