### PR TITLE
Release v1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "epicc"
-version = "1.0.0"
+version = "1.0.1"
 requires-python = ">=3.12"
 dependencies = [
     "streamlit>=1.55.0",

--- a/src/epicc/__init__.py
+++ b/src/epicc/__init__.py
@@ -7,6 +7,6 @@ unavailable there. `pyproject.toml` is kept in step with this value by
 `scripts/bump_version.py` and checked by `tests/epicc/test_version.py`.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Bumps `1.0.0` → `1.0.1` for the UI regression fixes merged in #72, which were released without a version bump.

Generated with `scripts/bump_version.py patch`, so both places the version is recorded stay in step:

- `src/epicc/__init__.py` — `__version__`, the runtime source of truth shown in the app header
- `pyproject.toml` — `version`

Patch bump is the right level here: #72 was a pure bug fix that restored the pre-#48 rendering, with no API or behaviour changes of its own.

`192 passed`, including `tests/epicc/test_version.py` which enforces that the two values match.

## After merging

This PR only changes the recorded version — it does not tag or publish. To cut the release:

```
git tag -a v1.0.1 -m "v1.0.1"
git push --follow-tags
```

Pushing the tag is what makes GitHub publish the release with notes generated from the PRs merged since v1.0.0 (#71, #72, and this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
